### PR TITLE
fix: サイドイベントページの説明文とスポンサー情報を修正

### DIFF
--- a/src/app/side-events/page.tsx
+++ b/src/app/side-events/page.tsx
@@ -20,7 +20,7 @@ const SideEventsPage = () => {
       </h1>
       <div className="bg-white p-6 flex flex-col gap-6 max-w-7xl mx-auto md:rounded-xl md:p-8 lg:p-10">
         <p className="md:text-lg">
-          TSKaigiのスポンサー企業によって実施される、TSKaigiのサイドイベントをご紹介します。ご参加お待ちしております！
+          TSKaigiのサイドイベントをご紹介します。ご参加お待ちしております！
           <br />※ 正確な情報は各イベントページをご確認ください。
         </p>
 

--- a/src/constants/sideEventList.ts
+++ b/src/constants/sideEventList.ts
@@ -19,7 +19,7 @@ export const sideEventList: SideEvent[] = [
     detail: `TSKaigi採択者によるトークと、TSKaigiのCfP選考担当者によるトークを通じて、CfP応募のコツや選考のポイントを学べる勉強会です。
 初めてCfPに応募しようと考えている方、応募を迷っている・応募に自信がない方におすすめです。`,
     tags: ["勉強会", "CfP"],
-    sponsors: ["フリー株式会社"],
+    sponsors: ["TSKaigi Association"],
     finishedAt: new Date("2026-02-09T21:30:00+09:00"),
   },
 ];


### PR DESCRIPTION
## 概要
サイドイベントページの説明文とスポンサー情報を修正しました。

## 変更内容
- 説明文から「スポンサー企業によって実施される」という表現を削除
- TSKaigi Mashup #4 CfP勉強会のスポンサーをTSKaigi Associationに修正