### PR TITLE
fix: 画面が大きいときやコンテンツが少ないときににフッターが浮いてしまう問題を修正

### DIFF
--- a/src/app/code-of-conduct/page.tsx
+++ b/src/app/code-of-conduct/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 
 const CodeOfConductPage = () => {
   return (
-    <main className="bg-blue-light-100 pt-16 py-10 md:px-8">
+    <main className="bg-blue-light-100 flex-1 pt-16 py-10 md:px-8">
       <h1 className="text-2xl font-bold text-blue-light-500 text-center py-10 md:py-16 md:text-3xl lg:text-4xl">
         TSKaigi行動規範
       </h1>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import { SeekingSponsorsSection } from "./_components/SeekingSponsorsSection";
 
 export default function Home() {
   return (
-    <main className="w-full flex flex-col items-center font-outfit">
+    <main className="w-full flex flex-col flex-1 items-center font-outfit">
       <EventCountdownBanner />
       <SeekingSponsorsSection />
     </main>

--- a/src/app/top/page.dev.tsx
+++ b/src/app/top/page.dev.tsx
@@ -4,7 +4,7 @@ import { MissionSection } from "../../components/MissionSection";
 
 export default function Home() {
   return (
-    <main className="pt-8 overflow-x-hidden">
+    <main className="flex-1 pt-8 overflow-x-hidden">
       <HeroSectionWithMotion />
       <MissionSection />
       <SponsorsBoardSection />


### PR DESCRIPTION
## 概要

大きいディスプレイで表示した際のフッターの位置の考慮ができていなかったので修正しました

## 変更内容

- main タグに `flex-1` がついていなかった箇所に付けるように修正

|ディザートップ|行動規範|
|-|-|
|<img width="1392" height="1660" alt="image" src="https://github.com/user-attachments/assets/f6380771-2883-485f-93d3-ba338cbc017f" />|<img width="1392" height="1660" alt="image" src="https://github.com/user-attachments/assets/ecedd013-d52b-4820-a20c-206ed2bf9a4c" />|