### PR TITLE
feat: サイドイベントフォームを改善

### DIFF
--- a/.github/ISSUE_TEMPLATE/side-event.yml
+++ b/.github/ISSUE_TEMPLATE/side-event.yml
@@ -1,6 +1,6 @@
 name: サイドイベント追加
 description: サイドイベントをWebサイトに追加する
-title: "[サイドイベント] イベント名をここに入力"
+title: "[サイドイベント追加]"
 labels: ["side-event"]
 body:
   - type: markdown
@@ -49,10 +49,9 @@ body:
     id: name
     attributes:
       label: イベント名
-      description: 空欄の場合はPRで手動入力が必要です
       placeholder: "TSKaigi Mashup #4 CfP勉強会"
     validations:
-      required: false
+      required: true
 
   - type: textarea
     id: detail

--- a/.github/scripts/add-side-event.js
+++ b/.github/scripts/add-side-event.js
@@ -68,6 +68,7 @@ module.exports = async ({ github, context, core }) => {
   if (dateRaw && !/^\d{4}-\d{2}-\d{2}$/.test(dateRaw)) {
     errors.push("開催日はYYYY-MM-DD形式で入力してください");
   }
+  if (!name) errors.push("イベント名が入力されていません");
 
   if (errors.length > 0) {
     core.setFailed(`入力エラー:\n${errors.join("\n")}`);
@@ -79,8 +80,7 @@ module.exports = async ({ github, context, core }) => {
   const finishedAt = calcFinishedAt(dateRaw);
 
   // 出力を設定（PR用）
-  const eventName = name || "【要入力】イベント名";
-  core.setOutput("name", eventName);
+  core.setOutput("name", name);
   core.setOutput("date", date);
   core.setOutput("link", link);
 
@@ -93,11 +93,11 @@ module.exports = async ({ github, context, core }) => {
       ? `\n    tags: [${tags.map((t) => `"${t}"`).join(", ")}],`
       : "";
 
-  const eventDetail = detail || "【要入力】イベント詳細";
+  const eventDetail = detail || "イベント詳細をここに入力してください";
 
   const newEvent = `  {
     date: "${date}",
-    name: "${eventName}",
+    name: "${name}",
     link: "${link}",
     thumbnail:
       "${thumbnail}",
@@ -120,5 +120,5 @@ module.exports = async ({ github, context, core }) => {
   fs.writeFileSync(filePath, updatedContent);
 
   console.log("Updated sideEventList.ts with new event:");
-  console.log({ date, eventName, link, thumbnail, eventDetail, tags, sponsors, finishedAt });
+  console.log({ date, name, link, thumbnail, detail: eventDetail, tags, sponsors, finishedAt });
 };


### PR DESCRIPTION
## Summary
- フィールド順序を変更（URL→スポンサー→日付→詳細）
- Connpass前提でURLフィールドの説明を改善
- スポンサーのカンマ区切りをわかりやすく（プレースホルダー改善）
- 日付入力をYYYY-MM-DD形式に変更し、自動で「M/D (曜日)」形式に変換
- 終了日時を開催日の翌日0:00として自動計算（手動入力不要に）
- イベント名・詳細を任意入力に変更（空欄時は「要入力」プレースホルダー）

## 変更点

### イシューテンプレート
1. タイトルに「[サイドイベント] イベント名をここに入力」を設定
2. フィールド順序: ConnpassURL → サムネイルURL → スポンサー → 開催日 → イベント名 → 詳細 → タグ
3. 終了日時フィールドを削除

### スクリプト
1. `formatDate()`: YYYY-MM-DD → "M/D (曜日)" 変換
2. `calcFinishedAt()`: 開催日の翌日0:00を自動計算
3. イベント名・詳細が空欄の場合は「【要入力】」プレースホルダーを設定

## Test plan
- [ ] 新しいフォームでイシューを作成
- [ ] 日付変換が正しく動作することを確認（例: 2026-05-23 → 5/23 (土)）
- [ ] PRが自動生成されることを確認