### PR TITLE
feat: サイドイベント追加ワークフローをSlack Workflow起票に対応

### DIFF
--- a/.github/scripts/add-side-event.js
+++ b/.github/scripts/add-side-event.js
@@ -7,7 +7,7 @@ module.exports = async ({ github, context, core }) => {
   function parseFormField(body, fieldName) {
     const regex = new RegExp(
       `### ${fieldName}\\s*\\n\\s*([\\s\\S]*?)(?=\\n###|$)`,
-      "i"
+      "i",
     );
     const match = body.match(regex);
     if (match) {
@@ -112,14 +112,20 @@ module.exports = async ({ github, context, core }) => {
   const currentContent = fs.readFileSync(filePath, "utf8");
 
   // 配列の最後（];の前）に新しいイベントを追加
-  const updatedContent = currentContent.replace(
-    /(\];\s*)$/,
-    `${newEvent}\n$1`
-  );
+  const updatedContent = currentContent.replace(/(\];\s*)$/, `${newEvent}\n$1`);
 
   // ファイルに書き込む
   fs.writeFileSync(filePath, updatedContent);
 
   console.log("Updated sideEventList.ts with new event:");
-  console.log({ date, name, link, thumbnail, detail: eventDetail, tags, sponsors, finishedAt });
+  console.log({
+    date,
+    name,
+    link,
+    thumbnail,
+    detail: eventDetail,
+    tags,
+    sponsors,
+    finishedAt,
+  });
 };

--- a/.github/workflows/add-side-event.yml
+++ b/.github/workflows/add-side-event.yml
@@ -6,8 +6,13 @@ on:
 
 jobs:
   add-side-event:
-    # side-eventラベルが付いているイシューのみ実行
-    if: contains(github.event.issue.labels.*.name, 'side-event')
+    # ラベル依存をやめて、タイトル or 本文で判定（Slack Workflow起票にも対応）
+    # - タイトルが固定なら startsWith が強い
+    # - 本文の見出し（## ConnpassイベントURL）が入っていれば「サイドイベント追加」とみなす
+    if: |
+      startsWith(github.event.issue.title, 'サイドイベント追加') ||
+      contains(github.event.issue.body, '## ConnpassイベントURL') ||
+      contains(github.event.issue.body, '### ConnpassイベントURL')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -17,6 +22,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      # 任意：このジョブで拾ったIssueには side-event ラベルを付与（運用しやすくなる）
+      - name: Ensure side-event label on issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = (context.payload.issue.labels || []).map(l => l.name);
+            if (!labels.includes('side-event')) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ['side-event'],
+              });
+            }
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- ラベル依存をやめて、タイトルまたは本文での判定に変更（Slack Workflow起票にも対応）
- side-eventラベルの自動付与ステップを追加
- スクリプトのフォーマット修正（Biome）

## Test plan
- [ ] Slack Workflowからの起票でワークフローが動作することを確認
- [ ] 手動でのイシュー作成でもワークフローが動作することを確認