### PR TITLE
feat: サイドイベントを日付の降順でソート

### DIFF
--- a/src/constants/sideEventList.ts
+++ b/src/constants/sideEventList.ts
@@ -9,7 +9,7 @@ export type SideEvent = {
   finishedAt: Date;
 };
 
-export const sideEventList: SideEvent[] = [
+const rawSideEventList: SideEvent[] = [
   {
     date: "2/9 (月)",
     name: "TSKaigi Mashup #4 プロポーザルの書き方とコツを学ぼう",
@@ -35,3 +35,8 @@ export const sideEventList: SideEvent[] = [
     finishedAt: new Date("2026-01-27T19:30:00+09:00"),
   },
 ];
+
+// 日付の降順（新しい順）でソート
+export const sideEventList = [...rawSideEventList].sort(
+  (a, b) => b.finishedAt.getTime() - a.finishedAt.getTime(),
+);


### PR DESCRIPTION
## Summary
- サイドイベント一覧を `finishedAt` の降順（新しい順）でソートするように変更
- ワークフローで末尾に追加されても、自動的に正しい順序で表示される

## Test plan
- [ ] サイドイベントページで新しいイベントが上に表示されることを確認