### PR TITLE
feat: PR作成時に2026-websiteチームをレビュアーに追加

### DIFF
--- a/.github/workflows/add-side-event.yml
+++ b/.github/workflows/add-side-event.yml
@@ -91,6 +91,7 @@ jobs:
           labels: |
             side-event
             automated
+          team-reviewers: 2026-website
 
       - name: Comment on issue
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
- サイドイベント追加ワークフローで作成されるPRに `2026-website` チームを自動的にレビュアーとして付与

## Note
`GITHUB_TOKEN` では組織チームへのレビュアー追加権限がない場合があります。その場合はPATまたはGitHub Appトークンへの変更が必要です。