### PR TITLE
fix: サイドイベント追加スクリプトの配列追加位置を修正

### DIFF
--- a/.github/scripts/add-side-event.js
+++ b/.github/scripts/add-side-event.js
@@ -111,8 +111,12 @@ module.exports = async ({ github, context, core }) => {
   const filePath = "src/constants/sideEventList.ts";
   const currentContent = fs.readFileSync(filePath, "utf8");
 
-  // 配列の最後（];の前）に新しいイベントを追加
-  const updatedContent = currentContent.replace(/(\];\s*)$/, `${newEvent}\n$1`);
+  // rawSideEventList配列の最後（];の前）に新しいイベントを追加
+  // ファイル末尾ではなく、最初の ];（rawSideEventList配列の終了）を探す
+  const updatedContent = currentContent.replace(
+    /(\];\s*\n)/,
+    `${newEvent}\n$1`,
+  );
 
   // ファイルに書き込む
   fs.writeFileSync(filePath, updatedContent);


### PR DESCRIPTION
## Summary
- ソート機能追加（#52）により `sideEventList.ts` の構造が変更されたため、スクリプトの追加位置を修正
- ファイル末尾ではなく、`rawSideEventList` 配列の終了位置（最初の `];`）を探すように変更

## 原因
- 以前: ファイル末尾が `];` だった
- 現在: ファイル末尾が `);`（ソート処理）になった

## Test plan
- [ ] サイドイベント追加イシューを作成してPRが生成されることを確認