### PR TITLE
refactor: サイドイベントのソート処理をpage.tsxに移動

### DIFF
--- a/.github/scripts/add-side-event.js
+++ b/.github/scripts/add-side-event.js
@@ -111,12 +111,8 @@ module.exports = async ({ github, context, core }) => {
   const filePath = "src/constants/sideEventList.ts";
   const currentContent = fs.readFileSync(filePath, "utf8");
 
-  // rawSideEventList配列の最後（];の前）に新しいイベントを追加
-  // 行頭の ]; を探す（型定義内の string[]; などにマッチしないように）
-  const updatedContent = currentContent.replace(
-    /^(\];\s*\n)/m,
-    `${newEvent}\n$1`,
-  );
+  // 配列の最後（];の前）に新しいイベントを追加
+  const updatedContent = currentContent.replace(/(\];\s*)$/, `${newEvent}\n$1`);
 
   // ファイルに書き込む
   fs.writeFileSync(filePath, updatedContent);

--- a/src/app/side-events/page.tsx
+++ b/src/app/side-events/page.tsx
@@ -28,9 +28,11 @@ const SideEventsPage = () => {
         </p>
 
         <div className="flex flex-col gap-6 md:gap-0">
-          {sideEventList.map((event) => (
-            <SideEventItem key={event.name} {...event} />
-          ))}
+          {[...sideEventList]
+            .sort((a, b) => b.finishedAt.getTime() - a.finishedAt.getTime())
+            .map((event) => (
+              <SideEventItem key={event.name} {...event} />
+            ))}
         </div>
       </div>
     </main>

--- a/src/constants/sideEventList.ts
+++ b/src/constants/sideEventList.ts
@@ -9,7 +9,7 @@ export type SideEvent = {
   finishedAt: Date;
 };
 
-const rawSideEventList: SideEvent[] = [
+export const sideEventList: SideEvent[] = [
   {
     date: "2/9 (月)",
     name: "TSKaigi Mashup #4 プロポーザルの書き方とコツを学ぼう",
@@ -35,8 +35,3 @@ const rawSideEventList: SideEvent[] = [
     finishedAt: new Date("2026-01-27T19:30:00+09:00"),
   },
 ];
-
-// 日付の降順（新しい順）でソート
-export const sideEventList = [...rawSideEventList].sort(
-  (a, b) => b.finishedAt.getTime() - a.finishedAt.getTime(),
-);


### PR DESCRIPTION
## Summary
- `sideEventList.ts` をシンプルな配列定義に戻す
- `page.tsx` で表示時に `finishedAt` の降順でソート
- ワークフロースクリプトの正規表現をシンプルに

## 理由
`sideEventList.ts` でソートすると、ワークフローの正規表現が複雑になり、型定義内の `string[];` にマッチしてしまう問題があった。
表示側でソートすることで、データファイルの構造をシンプルに保てる。

## Test plan
- [ ] サイドイベントページで新しいイベントが上に表示されることを確認
- [ ] サイドイベント追加ワークフローでPRが作成されることを確認