### PR TITLE
fix: PATを使用してチームレビュアーを設定

### DIFF
--- a/.github/workflows/add-side-event.yml
+++ b/.github/workflows/add-side-event.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TSKAIGI_2026_WEBSITE_ACTIONS }}
           commit-message: "feat: add side event - ${{ steps.parse.outputs.name }}"
           title: "feat: サイドイベント追加 - ${{ steps.parse.outputs.name }}"
           body: |


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` → `TSKAIGI_2026_WEBSITE_ACTIONS` (PAT) に変更
- これにより `team-reviewers: 2026-website` が正常に動作するようになる

## 背景
`GITHUB_TOKEN` では組織チームをレビュアーに設定する権限がないため、`repo` スコープ付きPATが必要

## Test plan
- [ ] サイドイベント追加イシューでPRが作成され、2026-websiteチームがレビュアーに設定されることを確認