### PR TITLE
fix: サブページのOGP画像が表示されない問題を修正

### DIFF
--- a/src/app/code-of-conduct/page.tsx
+++ b/src/app/code-of-conduct/page.tsx
@@ -4,9 +4,11 @@ export const metadata: Metadata = {
   title: "行動規範",
   twitter: {
     title: "行動規範",
+    images: ["/ogp.png"],
   },
   openGraph: {
     title: "行動規範",
+    images: ["/ogp.png"],
   },
   robots: "noindex, nofollow",
 };

--- a/src/app/side-events/page.tsx
+++ b/src/app/side-events/page.tsx
@@ -6,9 +6,11 @@ export const metadata: Metadata = {
   title: "サイドイベント",
   twitter: {
     title: "サイドイベント",
+    images: ["/ogp.png"],
   },
   openGraph: {
     title: "サイドイベント",
+    images: ["/ogp.png"],
   },
 };
 


### PR DESCRIPTION
## Summary
- サイドイベントページ・行動規範ページでOGP画像（ogp.png）が表示されない問題を修正
- Next.jsのMetadata APIでは子ページで `openGraph` / `twitter` オブジェクトを定義すると親layoutの設定が浅いマージで上書きされるため、`images` が失われていた
- 各ページの `openGraph` / `twitter` に `images: ["/ogp.png"]` を明示的に追加

## 変更ファイル
- `src/app/side-events/page.tsx`
- `src/app/code-of-conduct/page.tsx`

## Test plan
- [x] ビルドが成功すること
- [x] `/side-events` のHTMLに `og:image` メタタグで `/ogp.png` が含まれること
- [x] `/code-of-conduct` のHTMLに `og:image` メタタグで `/ogp.png` が含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)