### PR TITLE
fix: スタッフ情報追加時にGitHubのavaterUrlを使用した場合に拡張子がつかない問題を修正

### DIFF
--- a/.github/scripts/add-staff.ts
+++ b/.github/scripts/add-staff.ts
@@ -45,7 +45,8 @@ module.exports = async ({ core, context }: Args) => {
   const imageUrlObj = new URL(imageUrl);
   const ext = path.extname(imageUrlObj.pathname);
   const imageBytes = await (await fetch(imageUrl)).bytes();
-  const imagePath = `/staff/${githubUserId}${ext}`;
+  // 拡張子がない場合でもdiffで表示できるように.pngで保存する
+  const imagePath = `/staff/${githubUserId}${ext || ".png"}`;
   fs.writeFileSync(`public${imagePath}`, imageBytes);
 
   // 出力を設定（PR用）


### PR DESCRIPTION
## 概要

アイコン画像URL は任意にしており、入力がなかった場合は GitHub の avaterUrl を使うようにしていました。

GitHub の avaterUrl はユーザーがアップロードしたファイルによるためファイルの種類がまちまちということで拡張子がついていないようでした。

参考：https://api.github.com/users/kamekyame

- 現在のブラウザでは、画像のファイル名についている拡張子が違っていても、問題なく表示される
- 拡張子がないと PR の差分でバイナリ扱いになり画像の確認ができない

ことから、ファイルの拡張子を取得した結果が空文字であれば `.png` とするように修正しました

