### PR TITLE
fix: サイドイベントのタイトルがPC等で小さかった問題を修正

### DIFF
--- a/src/app/side-events/page.tsx
+++ b/src/app/side-events/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 const SideEventsPage = () => {
   return (
     <main className="bg-blue-light-100 pt-16 pb-10 flex-1 md:px-8 md:pb-16">
-      <h1 className="text-2xl font-bold text-blue-light-500 text-center py-10 md:py-16">
+      <h1 className="text-2xl font-bold text-blue-light-500 text-center py-10 md:py-16 md:text-3xl lg:text-4xl">
         サイドイベント
       </h1>
       <div className="bg-white p-6 flex flex-col gap-6 max-w-7xl mx-auto md:rounded-xl md:p-8 lg:p-10">


### PR DESCRIPTION
## 概要

サイドイベントのタイトル文字が画面幅が大きい画面だと小さかった問題を修正しました。

行動規範 と挙動を合わせた形です

Fix: #175 
