### PR TITLE
feat: MyTimetableのトーク詳細をドロワーで表示する

### DIFF
--- a/src/app/talks/me/MyTimetablePage.tsx
+++ b/src/app/talks/me/MyTimetablePage.tsx
@@ -13,6 +13,7 @@ import {
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { TalkDetailDrawer } from "@/components/talks/TalkDetailDrawer";
 import { TimelineColumn } from "@/components/talks/TimelineColumn";
 import {
   DesktopTimelineLayout,
@@ -598,6 +599,7 @@ export default function MyTimetablePage() {
   const [overlapState, setOverlapState] = useState<OverlapState>(null);
   const [isClearConfirmOpen, setIsClearConfirmOpen] = useState(false);
   const [isQrOpen, setIsQrOpen] = useState(false);
+  const [drawerTalk, setDrawerTalk] = useState<TalkWithMinutes | null>(null);
   const allTalksWithMinutes = useMemo(
     () => myTimetable.getAllTalksWithMinutes(),
     [],
@@ -811,6 +813,7 @@ export default function MyTimetablePage() {
                 participatedIds={participatedIds}
                 onClickTimeSlot={handleClickTimeSlot}
                 onRemoveTalk={removeTalk}
+                onTalkClick={setDrawerTalk}
               />
             </MobileTimelineLayout>
           </div>
@@ -825,6 +828,7 @@ export default function MyTimetablePage() {
                   participatedIds={participatedIds}
                   onClickTimeSlot={handleClickTimeSlot}
                   onRemoveTalk={removeTalk}
+                  onTalkClick={setDrawerTalk}
                 />
               }
               day2Column={
@@ -834,6 +838,7 @@ export default function MyTimetablePage() {
                   participatedIds={participatedIds}
                   onClickTimeSlot={handleClickTimeSlot}
                   onRemoveTalk={removeTalk}
+                  onTalkClick={setDrawerTalk}
                 />
               }
             />
@@ -882,6 +887,8 @@ export default function MyTimetablePage() {
       >
         <Link href="/talks">タイムテーブルへ</Link>
       </Button>
+
+      <TalkDetailDrawer talk={drawerTalk} onClose={() => setDrawerTalk(null)} />
     </main>
   );
 }

--- a/src/app/talks/your/YourTimetablePage.tsx
+++ b/src/app/talks/your/YourTimetablePage.tsx
@@ -4,6 +4,7 @@ import { List, Pencil } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
+import { TalkDetailDrawer } from "@/components/talks/TalkDetailDrawer";
 import { TimelineColumn } from "@/components/talks/TimelineColumn";
 import {
   DesktopTimelineLayout,
@@ -11,11 +12,16 @@ import {
 } from "@/components/talks/TimelineLayout";
 import { Button } from "@/components/ui/button";
 import type { EventDate } from "@/types/timetable-api";
-import { getTalksByDateFromIds, myTimetableQuery } from "@/utils/myTimetable";
+import {
+  getTalksByDateFromIds,
+  myTimetableQuery,
+  type TalkWithMinutes,
+} from "@/utils/myTimetable";
 
 export default function YourTimetablePage() {
   const searchParams = useSearchParams();
   const [currentEventDate, setCurrentEventDate] = useState<EventDate>("Day1");
+  const [drawerTalk, setDrawerTalk] = useState<TalkWithMinutes | null>(null);
 
   const { ids, participatedIds } = useMemo(
     () => myTimetableQuery.parse(searchParams),
@@ -61,6 +67,7 @@ export default function YourTimetablePage() {
                 eventDate={currentEventDate}
                 talks={talksByDate[currentEventDate]}
                 participatedIds={participatedIds}
+                onTalkClick={setDrawerTalk}
               />
             </MobileTimelineLayout>
           </div>
@@ -72,6 +79,7 @@ export default function YourTimetablePage() {
                   eventDate="Day1"
                   talks={talksByDate.Day1}
                   participatedIds={participatedIds}
+                  onTalkClick={setDrawerTalk}
                 />
               }
               day2Column={
@@ -79,12 +87,15 @@ export default function YourTimetablePage() {
                   eventDate="Day2"
                   talks={talksByDate.Day2}
                   participatedIds={participatedIds}
+                  onTalkClick={setDrawerTalk}
                 />
               }
             />
           </div>
         </div>
       </div>
+
+      <TalkDetailDrawer talk={drawerTalk} onClose={() => setDrawerTalk(null)} />
     </main>
   );
 }

--- a/src/components/talks/TalkDetailDrawer/index.tsx
+++ b/src/components/talks/TalkDetailDrawer/index.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { AnimatePresence, motion, useDragControls } from "framer-motion";
+import { ExternalLink, Github, Twitter, X } from "lucide-react";
+import Link from "next/link";
+import { useEffect } from "react";
+import { ProfileImage } from "@/components/talks/FallbackImage";
+import { TalkStatus } from "@/components/talks/TalkStatus";
+import { Button } from "@/components/ui/button";
+import { TALK_TYPE, TRACK, TRACK_STYLE } from "@/constants/timetable";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { cn } from "@/lib/utils";
+import { findSession } from "@/utils/getSession";
+import type { TalkWithMinutes } from "@/utils/myTimetable";
+
+function SpeakerSection({ talk }: { talk: TalkWithMinutes }) {
+  const { speaker } = talk;
+  return (
+    <div className="flex flex-col gap-3">
+      <h3 className="text-sm font-bold text-black-700">スピーカー</h3>
+      <div className="flex items-start gap-4">
+        <div className="relative w-16 h-16 rounded-full overflow-hidden shrink-0">
+          <ProfileImage
+            speakerName={speaker.name}
+            profileImageUrl={speaker.profileImageUrl}
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <p className="font-bold text-black-700">{speaker.name}</p>
+          {speaker.affiliation && (
+            <p className="text-xs text-black-500">{speaker.affiliation}</p>
+          )}
+          {speaker.position && (
+            <p className="text-xs text-black-500">{speaker.position}</p>
+          )}
+          <div className="flex items-center gap-3">
+            {speaker.xId && (
+              <Link
+                href={`https://x.com/${speaker.xId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-black-400 hover:text-black-700"
+                aria-label={`${speaker.name} のXプロフィール`}
+              >
+                <Twitter size={14} />
+              </Link>
+            )}
+            {speaker.githubId && (
+              <Link
+                href={`https://github.com/${speaker.githubId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-black-400 hover:text-black-700"
+                aria-label={`${speaker.name} のGitHubプロフィール`}
+              >
+                <Github size={14} />
+              </Link>
+            )}
+            {speaker.additionalLink && (
+              <Link
+                href={speaker.additionalLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-black-400 hover:text-black-700"
+                aria-label={`${speaker.name} の追加リンク`}
+              >
+                <ExternalLink size={14} />
+              </Link>
+            )}
+          </div>
+        </div>
+      </div>
+      {speaker.bio && (
+        <p className="text-sm text-black-600 whitespace-pre-line">
+          {speaker.bio}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function DrawerContent({ talk }: { talk: TalkWithMinutes }) {
+  const sessionDetail = findSession(talk.id);
+  const typeLabel = sessionDetail
+    ? TALK_TYPE[sessionDetail.sessionType].name
+    : null;
+
+  return (
+    <div className="flex-1 overflow-y-auto px-6 py-4 flex flex-col gap-6">
+      <div className="flex items-center gap-2 flex-wrap">
+        {typeLabel && (
+          <span className="text-sm text-black-500">{typeLabel}</span>
+        )}
+        <TalkStatus talkId={talk.id} />
+      </div>
+
+      <div>
+        <h2 className="text-xl font-bold text-black-700 leading-snug">
+          {talk.title}
+        </h2>
+        <div className="mt-2 flex items-center gap-2 flex-wrap text-sm text-black-500">
+          <span
+            className={cn(
+              "inline-block w-2.5 h-2.5 rounded-full shrink-0",
+              TRACK_STYLE[talk.track].bg,
+            )}
+          />
+          <span>
+            {talk.eventDate} / {talk.time} / {TRACK[talk.track].name}
+          </span>
+        </div>
+      </div>
+
+      <SpeakerSection talk={talk} />
+
+      <div>
+        <h3 className="text-sm font-bold text-black-700 mb-2">概要</h3>
+        <p className="text-sm text-black-500">（概要は後日公開予定です）</p>
+      </div>
+
+      <div className="mt-auto pt-4">
+        <Button asChild variant="outline" className="w-full gap-2">
+          <Link href={`/talks/${talk.id}`}>
+            <ExternalLink size={16} />
+            詳細ページで見る
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function TalkDetailDrawer({
+  talk,
+  onClose,
+}: {
+  talk: TalkWithMinutes | null;
+  onClose: () => void;
+}) {
+  const isDesktop = useMediaQuery("(min-width: 1024px)");
+  const dragControls = useDragControls();
+
+  useEffect(() => {
+    if (!talk) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [talk, onClose]);
+
+  useEffect(() => {
+    document.body.style.overflow = talk ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [talk]);
+
+  return (
+    <AnimatePresence>
+      {talk && (
+        <>
+          <motion.div
+            key="talk-drawer-overlay"
+            className="fixed inset-0 z-40 bg-black/40"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onClose}
+          />
+
+          {isDesktop ? (
+            <motion.div
+              key="talk-drawer-panel"
+              role="dialog"
+              aria-modal="true"
+              aria-label="トーク詳細"
+              className="fixed inset-y-0 right-0 z-50 w-full max-w-[480px] bg-white shadow-xl flex flex-col"
+              initial={{ x: "100%" }}
+              animate={{ x: 0 }}
+              exit={{ x: "100%" }}
+              transition={{ type: "spring", damping: 30, stiffness: 300 }}
+            >
+              <div className="flex items-center justify-between px-6 py-4 border-b border-black-200 shrink-0">
+                <h2 className="text-base font-bold text-black-700">
+                  トーク詳細
+                </h2>
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="text-black-500 hover:text-black-700 cursor-pointer"
+                  aria-label="閉じる"
+                >
+                  <X size={20} />
+                </button>
+              </div>
+              <DrawerContent talk={talk} />
+            </motion.div>
+          ) : (
+            <motion.div
+              key="talk-drawer-panel"
+              role="dialog"
+              aria-modal="true"
+              aria-label="トーク詳細"
+              className="fixed inset-x-0 bottom-0 z-50 h-[60vh] bg-white rounded-t-2xl shadow-xl flex flex-col"
+              initial={{ y: "100%" }}
+              animate={{ y: 0 }}
+              exit={{ y: "100%" }}
+              transition={{ type: "spring", damping: 30, stiffness: 300 }}
+              drag="y"
+              dragControls={dragControls}
+              dragListener={false}
+              dragConstraints={{ top: 0 }}
+              dragElastic={{ top: 0, bottom: 0.3 }}
+              onDragEnd={(_, info) => {
+                if (info.offset.y > 100 || info.velocity.y > 500) {
+                  onClose();
+                }
+              }}
+            >
+              <div
+                className="flex justify-center pt-3 pb-1 shrink-0 cursor-grab active:cursor-grabbing touch-none"
+                onPointerDown={(e) => dragControls.start(e)}
+              >
+                <div className="w-10 h-1.5 bg-black-200 rounded-full" />
+              </div>
+              <DrawerContent talk={talk} />
+            </motion.div>
+          )}
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/talks/TalkDetailDrawer/index.tsx
+++ b/src/components/talks/TalkDetailDrawer/index.tsx
@@ -95,9 +95,9 @@ function DrawerContent({ talk }: { talk: TalkWithMinutes }) {
       </div>
 
       <div>
-        <h2 className="text-xl font-bold text-black-700 leading-snug">
+        <h3 className="text-xl font-bold text-black-700 leading-snug">
           {talk.title}
-        </h2>
+        </h3>
         <div className="mt-2 flex items-center gap-2 flex-wrap text-sm text-black-500">
           <span
             className={cn(

--- a/src/components/talks/TalkDetailDrawer/index.tsx
+++ b/src/components/talks/TalkDetailDrawer/index.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button";
 import { TALK_TYPE, TRACK, TRACK_STYLE } from "@/constants/timetable";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { cn } from "@/lib/utils";
-import { findSession } from "@/utils/getSession";
+import { getSession } from "@/utils/getSession";
 import type { TalkWithMinutes } from "@/utils/myTimetable";
 
 function SpeakerSection({ talk }: { talk: TalkWithMinutes }) {
@@ -80,7 +80,7 @@ function SpeakerSection({ talk }: { talk: TalkWithMinutes }) {
 }
 
 function DrawerContent({ talk }: { talk: TalkWithMinutes }) {
-  const sessionDetail = findSession(talk.id);
+  const sessionDetail = getSession(talk.id);
   const typeLabel = sessionDetail
     ? TALK_TYPE[sessionDetail.sessionType].name
     : null;

--- a/src/components/talks/TalkDetailDrawer/index.tsx
+++ b/src/components/talks/TalkDetailDrawer/index.tsx
@@ -140,6 +140,7 @@ export function TalkDetailDrawer({
   const isDesktop = useMediaQuery("(min-width: 1024px)");
   const dragControls = useDragControls();
 
+  // オーバーレイクリック以外の閉じ手段として Esc キーに対応する
   useEffect(() => {
     if (!talk) return;
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -149,6 +150,7 @@ export function TalkDetailDrawer({
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [talk, onClose]);
 
+  // ドロワー表示中にページ本体をスクロールさせない
   useEffect(() => {
     document.body.style.overflow = talk ? "hidden" : "";
     return () => {

--- a/src/components/talks/TalkDetailDrawer/index.tsx
+++ b/src/components/talks/TalkDetailDrawer/index.tsx
@@ -120,9 +120,9 @@ function DrawerContent({ talk }: { talk: TalkWithMinutes }) {
 
       <div className="mt-auto pt-4">
         <Button asChild variant="outline" className="w-full gap-2">
-          <Link href={`/talks/${talk.id}`}>
-            <ExternalLink size={16} />
+          <Link href={`/talks/${talk.id}`} target="_blank">
             詳細ページで見る
+            <ExternalLink size={16} />
           </Link>
         </Button>
       </div>

--- a/src/components/talks/TimelineColumn/index.tsx
+++ b/src/components/talks/TimelineColumn/index.tsx
@@ -18,6 +18,7 @@ export function TimelineColumn({
   participatedIds,
   onClickTimeSlot,
   onRemoveTalk,
+  onTalkClick,
 }: {
   id?: string;
   eventDate: EventDate;
@@ -25,6 +26,7 @@ export function TimelineColumn({
   participatedIds: string[];
   onClickTimeSlot?: (eventDate: EventDate, minutes: number) => void;
   onRemoveTalk?: (id: string) => void;
+  onTalkClick?: (talk: TalkWithMinutes) => void;
 }) {
   const editable = !!onClickTimeSlot && !!onRemoveTalk;
   const participatedIdsSet = useMemo(
@@ -138,14 +140,26 @@ export function TimelineColumn({
                 ? `${talk.time} / ${TRACK[talk.track].name}`
                 : talk.time}
             </p>
-            <Link
-              href={`/talks/${talk.id}`}
-              className={`relative z-10 hover:underline block ${editable ? "" : "pr-4"}`}
-            >
-              <p className="mt-0.5 text-xs font-bold text-black-700 line-clamp-2">
-                {talk.title}
-              </p>
-            </Link>
+            {onTalkClick ? (
+              <button
+                type="button"
+                className={`relative z-10 hover:underline block text-left w-full ${editable ? "" : "pr-4"}`}
+                onClick={() => onTalkClick(talk)}
+              >
+                <p className="mt-0.5 text-xs font-bold text-black-700 line-clamp-2">
+                  {talk.title}
+                </p>
+              </button>
+            ) : (
+              <Link
+                href={`/talks/${talk.id}`}
+                className={`relative z-10 hover:underline block ${editable ? "" : "pr-4"}`}
+              >
+                <p className="mt-0.5 text-xs font-bold text-black-700 line-clamp-2">
+                  {talk.title}
+                </p>
+              </Link>
+            )}
             <p
               className={`relative z-10 mt-0.5 text-[10px] text-black-500 truncate ${editable ? "" : "pr-4"}`}
             >

--- a/src/components/talks/TimelineColumn/index.tsx
+++ b/src/components/talks/TimelineColumn/index.tsx
@@ -143,7 +143,7 @@ export function TimelineColumn({
             {onTalkClick ? (
               <button
                 type="button"
-                className={`relative z-10 hover:underline block text-left w-full ${editable ? "" : "pr-4"}`}
+                className={`relative z-10 cursor-pointer hover:underline block text-left w-full ${editable ? "" : "pr-4"}`}
                 onClick={() => onTalkClick(talk)}
               >
                 <p className="mt-0.5 text-xs font-bold text-black-700 line-clamp-2">

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    setMatches(mql.matches);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,5 +1,9 @@
 import { useEffect, useState } from "react";
 
+/**
+ * Tailwind のブレークポイント判定を CSS だけでは解決できない場合（レンダリング内容の出し分けなど）に使う。
+ * 単純な表示/非表示なら CSS の responsive クラスを優先すること。
+ */
 export function useMediaQuery(query: string): boolean {
   const [matches, setMatches] = useState(() => {
     if (typeof window === "undefined") return false;

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,7 +1,10 @@
 import { useEffect, useState } from "react";
 
 export function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState(false);
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(query).matches;
+  });
 
   useEffect(() => {
     const mql = window.matchMedia(query);

--- a/src/utils/getSession.ts
+++ b/src/utils/getSession.ts
@@ -22,7 +22,7 @@ export type SessionDetail = {
   endTime: number;
 };
 
-function lookupSession(id: string): SessionDetail | null {
+function lookupSession(id: SessionId): SessionDetail | null {
   for (const day of timetableList) {
     const trackNameMap: Record<string, string> = {};
     for (const t of day.tracks) {
@@ -60,6 +60,6 @@ export function getSession(id: SessionId): SessionDetail {
   return result;
 }
 
-export function findSession(id: string): SessionDetail | null {
+export function findSession(id: SessionId): SessionDetail | null {
   return lookupSession(id);
 }

--- a/src/utils/getSession.ts
+++ b/src/utils/getSession.ts
@@ -22,7 +22,7 @@ export type SessionDetail = {
   endTime: number;
 };
 
-function lookupSession(id: SessionId): SessionDetail | null {
+export function getSession(id: SessionId): SessionDetail {
   for (const day of timetableList) {
     const trackNameMap: Record<string, string> = {};
     for (const t of day.tracks) {
@@ -51,15 +51,5 @@ function lookupSession(id: SessionId): SessionDetail | null {
       }
     }
   }
-  return null;
-}
-
-export function getSession(id: SessionId): SessionDetail {
-  const result = lookupSession(id);
-  if (!result) notFound();
-  return result;
-}
-
-export function findSession(id: SessionId): SessionDetail | null {
-  return lookupSession(id);
+  notFound();
 }

--- a/src/utils/getSession.ts
+++ b/src/utils/getSession.ts
@@ -22,7 +22,7 @@ export type SessionDetail = {
   endTime: number;
 };
 
-export function getSession(id: SessionId): SessionDetail {
+function lookupSession(id: string): SessionDetail | null {
   for (const day of timetableList) {
     const trackNameMap: Record<string, string> = {};
     for (const t of day.tracks) {
@@ -51,5 +51,15 @@ export function getSession(id: SessionId): SessionDetail {
       }
     }
   }
-  notFound();
+  return null;
+}
+
+export function getSession(id: SessionId): SessionDetail {
+  const result = lookupSession(id);
+  if (!result) notFound();
+  return result;
+}
+
+export function findSession(id: string): SessionDetail | null {
+  return lookupSession(id);
 }


### PR DESCRIPTION
## 概要

トークタイトルをクリックするたびに詳細ページへ遷移していた動線を改善し、ドロワー形式のインライン表示に変更しました。

## 変更点

- TalkDetailDrawer コンポーネントを新規追加
- スワイプで閉じる挙動を実現するため、shadcn/ui の Sheet は使わずに実装

| PC | Tablet | Phone |
| --- | --- | --- |
|<img width="2380" height="1862" alt="pc" src="https://github.com/user-attachments/assets/7b959535-78fc-4e7b-9d8f-5f5f4cb4e37f" />|<img width="1164" height="1546" alt="tablet" src="https://github.com/user-attachments/assets/a55acf85-cb39-405a-af3e-10133331c249" />|<img width="756" height="1338" alt="phone" src="https://github.com/user-attachments/assets/3625fecf-215a-4b7e-b23f-9b9b4bc001ee" />|



## 備考

- OGP画像はドロワーでは非表示（詳細ページとの棲み分け）