### PR TITLE
fix: 開催日と年の修正漏れ対応

### DIFF
--- a/.github/ISSUE_TEMPLATE/side-event.yml
+++ b/.github/ISSUE_TEMPLATE/side-event.yml
@@ -39,8 +39,8 @@ body:
     id: date
     attributes:
       label: 開催日
-      description: YYYY-MM-DD形式で入力してください（自動的に「5/23 (金)」形式に変換されます）
-      placeholder: "2026-05-23"
+      description: YYYY-MM-DD形式で入力してください（自動的に「5/22 (金)」形式に変換されます）
+      placeholder: "2026-05-22"
     validations:
       required: true
 

--- a/src/app/talks/layout.tsx
+++ b/src/app/talks/layout.tsx
@@ -3,18 +3,18 @@ import { TourWrapper } from "@/components/talks/Tour";
 
 export const metadata: Metadata = {
   title: {
-    template: "%s | TSKaigi 2025",
+    template: "%s | TSKaigi 2026",
     default: "タイムテーブル",
   },
   twitter: {
     title: {
-      template: "%s | TSKaigi 2025",
+      template: "%s | TSKaigi 2026",
       default: "タイムテーブル",
     },
   },
   openGraph: {
     title: {
-      template: "%s | TSKaigi 2025",
+      template: "%s | TSKaigi 2026",
       default: "タイムテーブル",
     },
   },

--- a/src/components/HeroSectionWithMotion/index.tsx
+++ b/src/components/HeroSectionWithMotion/index.tsx
@@ -138,7 +138,7 @@ export function HeroSectionWithMotion() {
       className="relative max-w-[1280px] mx-auto aspect-[32/15]"
     >
       <h1>
-        <span className="sr-only">TSKaigi 2025 5月23日、24日 東京、神田</span>
+        <span className="sr-only">TSKaigi 2026 5月22日、23日 東京、神田</span>
         <img
           className="fadein absolute top-[43.3%] left-[26.25%] w-[25.85%] h-auto origin-center"
           src="/logo.png"

--- a/src/components/talks/EventDateTab/index.tsx
+++ b/src/components/talks/EventDateTab/index.tsx
@@ -13,7 +13,7 @@ export function EventDateTab({ currentDate, onTabChange }: Props) {
       <div className="inline-flex rounded-lg overflow-hidden">
         {EVENT_DATES.map((date) => {
           const isActive = date === currentDate;
-          const dateText = date === "Day1" ? "Day 1  5/23" : "Day 2  5/24";
+          const dateText = date === "Day1" ? "Day 1  5/22" : "Day 2  5/23";
 
           return (
             <button

--- a/src/constants/timetable/talkList.ts
+++ b/src/constants/timetable/talkList.ts
@@ -11,8 +11,8 @@ export const EVENT_DATES: EventDate[] = ["Day1", "Day2"];
 export const TRACK_KEYS: TrackKey[] = ["LEVERAGES", "UPSIDER", "RIGHTTOUCH"];
 
 export const EVENT_DATE: Record<EventDate, string> = {
-  Day1: "2026-05-23",
-  Day2: "2026-05-24",
+  Day1: "2026-05-22",
+  Day2: "2026-05-23",
 };
 
 export const TRACK_STYLE: Record<

--- a/src/constants/timetable/timetable.ts
+++ b/src/constants/timetable/timetable.ts
@@ -23,10 +23,10 @@ export const TRACK: Record<TrackKey, Track> = {
   },
 };
 
+/** 2026-05-22T00:00:00+09:00 in unix seconds */
+const DAY1_BASE = 1779375600;
 /** 2026-05-23T00:00:00+09:00 in unix seconds */
-const DAY1_BASE = 1779462000;
-/** 2026-05-24T00:00:00+09:00 in unix seconds */
-const DAY2_BASE = 1779548400;
+const DAY2_BASE = 1779462000;
 
 /** HH:MM → unix timestamp (seconds) */
 const d1 = (h: number, m: number) => DAY1_BASE + h * 3600 + m * 60;
@@ -34,7 +34,7 @@ const d2 = (h: number, m: number) => DAY2_BASE + h * 3600 + m * 60;
 
 const day1: TimetableResponse = {
   day: "Day1",
-  date: "2026-05-23",
+  date: "2026-05-22",
   tracks: Object.values(TRACK),
   slots: [
     // 10:00–10:40 一般開場
@@ -561,7 +561,7 @@ const day1: TimetableResponse = {
 
 const day2: TimetableResponse = {
   day: "Day2",
-  date: "2026-05-24",
+  date: "2026-05-23",
   tracks: Object.values(TRACK),
   slots: [
     // 10:00–10:40 一般開場


### PR DESCRIPTION
## 概要

各所に2025の日程のまま残っていた日付表記を修正

タイムテーブルのランチスロットのラベルがDay1/Day2で逆になっていたのを修正

## UI上の変更点

タイムテーブルの箇所

| Before | After |
|--------|--------|
| <img  height="314" alt="Screenshot 2026-04-22 at 12 12 24" src="https://github.com/user-attachments/assets/335b9593-b0cb-43b7-866e-86aa82b7541a" /> | <img height="314" alt="Screenshot 2026-04-22 at 12 12 10" src="https://github.com/user-attachments/assets/44fdd039-afa5-4702-937a-c4af0634a35c" /> | 

## 備考

https://tskaigi.slack.com/archives/C062J30MAG6/p1776827637195269