### PR TITLE
fix: タイムテーブルのランチ/スポンサーセッションをDay2に修正

### DIFF
--- a/src/constants/timetable/timetable.ts
+++ b/src/constants/timetable/timetable.ts
@@ -160,12 +160,12 @@ const day1: TimetableResponse = {
       endTime: d1(12, 30),
       label: "ランチ配布",
     },
-    // 12:30–13:30 ランチ/スポンサーセッション
+    // 12:30–13:30 ランチ
     {
       slotType: "shared",
       startTime: d1(12, 30),
       endTime: d1(13, 30),
-      label: "ランチ/スポンサーセッション",
+      label: "ランチ",
     },
     // 13:30–13:40 休憩
     {
@@ -722,12 +722,12 @@ const day2: TimetableResponse = {
       endTime: d2(12, 30),
       label: "ランチ配布",
     },
-    // 12:30–13:30 ランチ
+    // 12:30–13:30 ランチ/スポンサーセッション
     {
       slotType: "shared",
       startTime: d2(12, 30),
       endTime: d2(13, 30),
-      label: "ランチ",
+      label: "ランチ/スポンサーセッション",
     },
     // 13:30–13:40 休憩
     {


### PR DESCRIPTION
## 概要

タイムテーブルのランチスロットのラベルがDay1/Day2で逆になっていたのを修正

| | 修正前 | 修正後 |
|---|---|---|
| Day1 | ランチ/スポンサーセッション | ランチ |
| Day2 | ランチ | ランチ/スポンサーセッション |

## UI上の変更箇所

<img width="361" height="162" alt="Screenshot 2026-04-22 at 12 23 04" src="https://github.com/user-attachments/assets/4e24bd25-fa4a-4a47-ad0b-5eebceb75cb8" />
