### PR TITLE
feat(timetable): Day1ハンズオンにconnpassリンクを追加

### DIFF
--- a/src/components/talks/DayTimeTable/index.tsx
+++ b/src/components/talks/DayTimeTable/index.tsx
@@ -21,11 +21,7 @@ import type {
 } from "@/types/timetable-api";
 import { myTimetable } from "@/utils/myTimetable";
 
-function SlotTrackHeader({
-  track,
-}: {
-  track: TimetableResponse["tracks"][number];
-}) {
+function SlotTrackHeader({ track }: { track: TimetableResponse["tracks"][number] }) {
   const [copySuccess, setCopySuccess] = useState(false);
   const key = track.id as TrackKey;
   const style = TRACK_STYLE[key];
@@ -62,13 +58,7 @@ function SlotTrackHeader({
   );
 }
 
-function TimeSlot({
-  timeText,
-  isActive = false,
-}: {
-  timeText: string;
-  isActive?: boolean;
-}) {
+function TimeSlot({ timeText, isActive = false }: { timeText: string; isActive?: boolean }) {
   return (
     <div
       className={`relative flex flex-col gap-2 p-2 items-center justify-center text-center w-full h-full md:w-[99px] lg:w-[125px] ${
@@ -144,9 +134,7 @@ function TrackCell({
   const style = TRACK_STYLE[trackKey];
 
   if (content.type === "override") {
-    return (
-      <div className="bg-gray-50 px-5 h-16 flex items-center justify-center text-black-700" />
-    );
+    return <div className="bg-gray-50 px-5 h-16 flex items-center justify-center text-black-700" />;
   }
 
   if (content.type === "closed") {
@@ -192,14 +180,7 @@ function TrackCell({
     );
   }
 
-  return (
-    <SessionCell
-      content={content}
-      trackKey={trackKey}
-      trackName={trackName}
-      id={id}
-    />
-  );
+  return <SessionCell content={content} trackKey={trackKey} trackName={trackName} id={id} />;
 }
 
 function TriangleBadge({ cssVar }: { cssVar: string }) {
@@ -220,11 +201,7 @@ function TriangleBadge({ cssVar }: { cssVar: string }) {
   );
 }
 
-function SessionTypeLabel({
-  sessionType,
-}: {
-  sessionType: SessionTrack["sessionType"];
-}) {
+function SessionTypeLabel({ sessionType }: { sessionType: SessionTrack["sessionType"] }) {
   const { name, color } = TALK_TYPE[sessionType];
   return (
     <span
@@ -279,10 +256,7 @@ function SessionCell({
           const speakerName = master?.speaker.name ?? "";
           return (
             <div key={ref.id} className="flex flex-col gap-1">
-              <Link
-                href={`/talks/${ref.id}`}
-                className="underline hover:text-blue-purple-500"
-              >
+              <Link href={`/talks/${ref.id}`} className="underline hover:text-blue-purple-500">
                 <p className="text-[16px]">{title}</p>
               </Link>
               <div className="flex items-center gap-2">
@@ -307,6 +281,7 @@ type ResolvedSpanGroup = {
   label: string;
   slotIndexStart: number;
   slotIndexEnd: number;
+  link?: string;
 };
 
 function resolveSpanGroups(
@@ -325,6 +300,7 @@ function resolveSpanGroups(
       label: group.label,
       slotIndexStart: startIdx,
       slotIndexEnd: endIdx,
+      link: group.link,
     });
   }
   return resolved;
@@ -332,7 +308,7 @@ function resolveSpanGroups(
 
 function buildSpanMap(resolved: ResolvedSpanGroup[]) {
   const hiddenCells = new Set<string>();
-  const spanCells = new Map<string, { rowSpan: number; label: string }>();
+  const spanCells = new Map<string, { rowSpan: number; label: string; link?: string }>();
 
   for (const group of resolved) {
     const rowSpan = group.slotIndexEnd - group.slotIndexStart + 1;
@@ -340,6 +316,7 @@ function buildSpanMap(resolved: ResolvedSpanGroup[]) {
       spanCells.set(`${group.slotIndexStart}-${track}`, {
         rowSpan,
         label: group.label,
+        link: group.link,
       });
       for (let i = group.slotIndexStart + 1; i <= group.slotIndexEnd; i++) {
         hiddenCells.add(`${i}-${track}`);
@@ -365,7 +342,7 @@ function SpanGroupSection({
   startIndex: number;
   resolvedSpanGroups: ResolvedSpanGroup[];
   hiddenCells: Set<string>;
-  spanCells: Map<string, { rowSpan: number; label: string }>;
+  spanCells: Map<string, { rowSpan: number; label: string; link?: string }>;
   trackNames: Record<string, string>;
   isSessionActiveFn: (id: string) => boolean;
   sessionRefs: React.RefObject<Record<string, HTMLDivElement | null>>;
@@ -374,10 +351,7 @@ function SpanGroupSection({
   const group = resolvedSpanGroups.find((g) => g.slotIndexStart === startIndex);
   if (!group) return null;
 
-  const slotsInGroup = slots.slice(
-    group.slotIndexStart,
-    group.slotIndexEnd + 1,
-  );
+  const slotsInGroup = slots.slice(group.slotIndexStart, group.slotIndexEnd + 1);
   const totalRows = slotsInGroup.length;
 
   return (
@@ -387,10 +361,7 @@ function SpanGroupSection({
         {slotsInGroup.map((slot) => {
           if (slot.slotType !== "individual") return null;
           const timeId = myTimetable.formatTime(slot.startTime);
-          const timeText = myTimetable.formatTimeRange(
-            slot.startTime,
-            slot.endTime,
-          );
+          const timeText = myTimetable.formatTimeRange(slot.startTime, slot.endTime);
           const active = isSessionActiveFn(timeId);
 
           const hasSession =
@@ -422,10 +393,7 @@ function SpanGroupSection({
           if (slot.slotType !== "individual") return null;
           const idx = group.slotIndexStart + i;
           const timeId = myTimetable.formatTime(slot.startTime);
-          const timeText = myTimetable.formatTimeRange(
-            slot.startTime,
-            slot.endTime,
-          );
+          const timeText = myTimetable.formatTimeRange(slot.startTime, slot.endTime);
           const active = isSessionActiveFn(timeId);
 
           const hasSession =
@@ -451,9 +419,7 @@ function SpanGroupSection({
                 if (span) {
                   const spanContent = slot.tracks[key];
                   const spanSessionId =
-                    spanContent.type === "session"
-                      ? spanContent.sessions[0]?.id
-                      : undefined;
+                    spanContent.type === "session" ? spanContent.sessions[0]?.id : undefined;
                   return (
                     <div
                       key={key}
@@ -463,7 +429,18 @@ function SpanGroupSection({
                       }}
                     >
                       <TriangleBadge cssVar={TRACK_STYLE[key].cssVar} />
-                      {span.label}
+                      {span.link ? (
+                        <Link
+                          href={span.link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="underline hover:text-blue-purple-500"
+                        >
+                          {span.label}
+                        </Link>
+                      ) : (
+                        span.label
+                      )}
                       {/* {spanSessionId && (
                         <AddToMyTimetableButton
                           talkId={spanSessionId}
@@ -505,11 +482,10 @@ export function DayTimeTable({ data }: { data: TimetableResponse }) {
     [data.slots],
   );
 
-  const { showScrollButton, scrollToCurrentSession, isSessionActive } =
-    useTimetable({
-      sessionTimeTable,
-      sessionElements: sessionRefs.current,
-    });
+  const { showScrollButton, scrollToCurrentSession, isSessionActive } = useTimetable({
+    sessionTimeTable,
+    sessionElements: sessionRefs.current,
+  });
 
   const trackNames = useMemo(() => {
     const map: Record<string, string> = {};
@@ -607,7 +583,7 @@ function SlotList({
   spanCoveredIndices: Set<number>;
   spanStartIndices: Set<number>;
   hiddenCells: Set<string>;
-  spanCells: Map<string, { rowSpan: number; label: string }>;
+  spanCells: Map<string, { rowSpan: number; label: string; link?: string }>;
   trackNames: Record<string, string>;
   isSessionActive: (id: string) => boolean;
   sessionRefs: React.RefObject<Record<string, HTMLDivElement | null>>;
@@ -617,10 +593,7 @@ function SlotList({
   return (
     <>
       {data.slots.map((slot, slotIndex) => {
-        if (
-          spanCoveredIndices.has(slotIndex) &&
-          !spanStartIndices.has(slotIndex)
-        ) {
+        if (spanCoveredIndices.has(slotIndex) && !spanStartIndices.has(slotIndex)) {
           return null;
         }
 
@@ -643,10 +616,7 @@ function SlotList({
         }
 
         const timeId = myTimetable.formatTime(slot.startTime);
-        const timeText = myTimetable.formatTimeRange(
-          slot.startTime,
-          slot.endTime,
-        );
+        const timeText = myTimetable.formatTimeRange(slot.startTime, slot.endTime);
         const active = isSessionActive(timeId);
 
         if (slot.slotType === "shared") {
@@ -707,8 +677,7 @@ function IndividualSlotRow({
       <TimeSlot timeText={timeText} isActive={isActive} />
       {TRACK_KEYS.map((key) => {
         const content = slot.tracks[key];
-        const shouldAssignTourId =
-          isFirstSession && !tourIdAssigned && content.type === "session";
+        const shouldAssignTourId = isFirstSession && !tourIdAssigned && content.type === "session";
         if (shouldAssignTourId) tourIdAssigned = true;
         return (
           <TrackCell

--- a/src/components/talks/DayTimeTable/index.tsx
+++ b/src/components/talks/DayTimeTable/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Copy } from "lucide-react";
+import { Copy, ExternalLink } from "lucide-react";
 import Link from "next/link";
 import React, { useMemo, useRef, useState } from "react";
 // import { AddToMyTimetableButton } from "@/components/talks/AddToMyTimetableButton";
@@ -21,11 +21,7 @@ import type {
 } from "@/types/timetable-api";
 import { myTimetable } from "@/utils/myTimetable";
 
-function SlotTrackHeader({
-  track,
-}: {
-  track: TimetableResponse["tracks"][number];
-}) {
+function SlotTrackHeader({ track }: { track: TimetableResponse["tracks"][number] }) {
   const [copySuccess, setCopySuccess] = useState(false);
   const key = track.id as TrackKey;
   const style = TRACK_STYLE[key];
@@ -62,13 +58,7 @@ function SlotTrackHeader({
   );
 }
 
-function TimeSlot({
-  timeText,
-  isActive = false,
-}: {
-  timeText: string;
-  isActive?: boolean;
-}) {
+function TimeSlot({ timeText, isActive = false }: { timeText: string; isActive?: boolean }) {
   return (
     <div
       className={`relative flex flex-col gap-2 p-2 items-center justify-center text-center w-full h-full md:w-[99px] lg:w-[125px] ${
@@ -144,9 +134,7 @@ function TrackCell({
   const style = TRACK_STYLE[trackKey];
 
   if (content.type === "override") {
-    return (
-      <div className="bg-gray-50 px-5 h-16 flex items-center justify-center text-black-700" />
-    );
+    return <div className="bg-gray-50 px-5 h-16 flex items-center justify-center text-black-700" />;
   }
 
   if (content.type === "closed") {
@@ -192,13 +180,52 @@ function TrackCell({
     );
   }
 
+  return <SessionCell content={content} trackKey={trackKey} trackName={trackName} id={id} />;
+}
+
+function SpanCell({
+  label,
+  link,
+  trackKey,
+  trackName,
+  rowSpan,
+}: {
+  label: string;
+  link?: string;
+  trackKey: TrackKey;
+  trackName: string;
+  rowSpan?: number;
+}) {
+  const style = TRACK_STYLE[trackKey];
   return (
-    <SessionCell
-      content={content}
-      trackKey={trackKey}
-      trackName={trackName}
-      id={id}
-    />
+    <div
+      className="bg-white px-5 pt-10 pb-4 md:py-5 min-h-32 flex flex-col gap-2 items-center justify-center text-black-700 relative"
+      style={rowSpan ? { gridRow: `span ${rowSpan}` } : undefined}
+    >
+      <div
+        className={cn(
+          style.bg,
+          style.text,
+          "block md:hidden py-1 px-2 absolute top-0 left-0 text-xs font-bold",
+        )}
+      >
+        {trackName}
+      </div>
+      <TriangleBadge cssVar={style.cssVar} />
+      {link ? (
+        <a
+          href={link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-blue-purple-500 inline-flex items-center gap-1"
+        >
+          <span>{label}</span>
+          <ExternalLink className="h-4 w-4" aria-hidden="true" />
+        </a>
+      ) : (
+        label
+      )}
+    </div>
   );
 }
 
@@ -220,11 +247,7 @@ function TriangleBadge({ cssVar }: { cssVar: string }) {
   );
 }
 
-function SessionTypeLabel({
-  sessionType,
-}: {
-  sessionType: SessionTrack["sessionType"];
-}) {
+function SessionTypeLabel({ sessionType }: { sessionType: SessionTrack["sessionType"] }) {
   const { name, color } = TALK_TYPE[sessionType];
   return (
     <span
@@ -279,10 +302,7 @@ function SessionCell({
           const speakerName = master?.speaker.name ?? "";
           return (
             <div key={ref.id} className="flex flex-col gap-1">
-              <Link
-                href={`/talks/${ref.id}`}
-                className="underline hover:text-blue-purple-500"
-              >
+              <Link href={`/talks/${ref.id}`} className="underline hover:text-blue-purple-500">
                 <p className="text-[16px]">{title}</p>
               </Link>
               <div className="flex items-center gap-2">
@@ -334,10 +354,7 @@ function resolveSpanGroups(
 
 function buildSpanMap(resolved: ResolvedSpanGroup[]) {
   const hiddenCells = new Set<string>();
-  const spanCells = new Map<
-    string,
-    { rowSpan: number; label: string; link?: string }
-  >();
+  const spanCells = new Map<string, { rowSpan: number; label: string; link?: string }>();
 
   for (const group of resolved) {
     const rowSpan = group.slotIndexEnd - group.slotIndexStart + 1;
@@ -380,23 +397,18 @@ function SpanGroupSection({
   const group = resolvedSpanGroups.find((g) => g.slotIndexStart === startIndex);
   if (!group) return null;
 
-  const slotsInGroup = slots.slice(
-    group.slotIndexStart,
-    group.slotIndexEnd + 1,
-  );
+  const slotsInGroup = slots.slice(group.slotIndexStart, group.slotIndexEnd + 1);
   const totalRows = slotsInGroup.length;
 
   return (
     <>
-      {/* モバイル: 通常レイアウト */}
+      {/* モバイル: spanはhiddenCells/spanCellsを参照しつつ縦に積む */}
       <div className="md:hidden">
-        {slotsInGroup.map((slot) => {
+        {slotsInGroup.map((slot, i) => {
           if (slot.slotType !== "individual") return null;
+          const idx = group.slotIndexStart + i;
           const timeId = myTimetable.formatTime(slot.startTime);
-          const timeText = myTimetable.formatTimeRange(
-            slot.startTime,
-            slot.endTime,
-          );
+          const timeText = myTimetable.formatTimeRange(slot.startTime, slot.endTime);
           const active = isSessionActiveFn(timeId);
 
           const hasSession =
@@ -404,18 +416,47 @@ function SpanGroupSection({
             TRACK_KEYS.some((k) => slot.tracks[k].type === "session");
           if (hasSession) firstSessionFoundRef.current = true;
 
+          let tourIdAssigned = false;
           return (
-            <IndividualSlotRow
+            <GridRow
               key={timeId}
-              slot={slot}
-              timeText={timeText}
-              isActive={active}
-              trackNames={trackNames}
-              isFirstSession={hasSession}
               refHandler={(el) => {
                 sessionRefs.current[timeId] = el;
               }}
-            />
+            >
+              <TimeSlot timeText={timeText} isActive={active} />
+              {TRACK_KEYS.map((key) => {
+                const cellKey = `${idx}-${key}`;
+                if (hiddenCells.has(cellKey)) return null;
+
+                const span = spanCells.get(cellKey);
+                if (span) {
+                  return (
+                    <SpanCell
+                      key={key}
+                      label={span.label}
+                      link={span.link}
+                      trackKey={key}
+                      trackName={trackNames[key] ?? key}
+                    />
+                  );
+                }
+
+                const content = slot.tracks[key];
+                const shouldAssignTourId =
+                  hasSession && !tourIdAssigned && content.type === "session";
+                if (shouldAssignTourId) tourIdAssigned = true;
+                return (
+                  <TrackCell
+                    key={key}
+                    content={content}
+                    trackKey={key}
+                    trackName={trackNames[key] ?? key}
+                    id={shouldAssignTourId ? "tour-add-button" : undefined}
+                  />
+                );
+              })}
+            </GridRow>
           );
         })}
       </div>
@@ -428,10 +469,7 @@ function SpanGroupSection({
           if (slot.slotType !== "individual") return null;
           const idx = group.slotIndexStart + i;
           const timeId = myTimetable.formatTime(slot.startTime);
-          const timeText = myTimetable.formatTimeRange(
-            slot.startTime,
-            slot.endTime,
-          );
+          const timeText = myTimetable.formatTimeRange(slot.startTime, slot.endTime);
           const active = isSessionActiveFn(timeId);
 
           const hasSession =
@@ -455,39 +493,15 @@ function SpanGroupSection({
 
                 const span = spanCells.get(cellKey);
                 if (span) {
-                  const spanContent = slot.tracks[key];
-                  const spanSessionId =
-                    spanContent.type === "session"
-                      ? spanContent.sessions[0]?.id
-                      : undefined;
                   return (
-                    <div
+                    <SpanCell
                       key={key}
-                      className="bg-white px-5 py-5 min-h-32 flex flex-col gap-2 items-center justify-center text-black-700 relative"
-                      style={{
-                        gridRow: `span ${span.rowSpan}`,
-                      }}
-                    >
-                      <TriangleBadge cssVar={TRACK_STYLE[key].cssVar} />
-                      {span.link ? (
-                        <Link
-                          href={span.link}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="underline hover:text-blue-purple-500"
-                        >
-                          {span.label}
-                        </Link>
-                      ) : (
-                        span.label
-                      )}
-                      {/* {spanSessionId && (
-                        <AddToMyTimetableButton
-                          talkId={spanSessionId}
-                          withCheckbox
-                        />
-                      )} */}
-                    </div>
+                      label={span.label}
+                      link={span.link}
+                      trackKey={key}
+                      trackName={trackNames[key] ?? key}
+                      rowSpan={span.rowSpan}
+                    />
                   );
                 }
 
@@ -522,11 +536,10 @@ export function DayTimeTable({ data }: { data: TimetableResponse }) {
     [data.slots],
   );
 
-  const { showScrollButton, scrollToCurrentSession, isSessionActive } =
-    useTimetable({
-      sessionTimeTable,
-      sessionElements: sessionRefs.current,
-    });
+  const { showScrollButton, scrollToCurrentSession, isSessionActive } = useTimetable({
+    sessionTimeTable,
+    sessionElements: sessionRefs.current,
+  });
 
   const trackNames = useMemo(() => {
     const map: Record<string, string> = {};
@@ -634,10 +647,7 @@ function SlotList({
   return (
     <>
       {data.slots.map((slot, slotIndex) => {
-        if (
-          spanCoveredIndices.has(slotIndex) &&
-          !spanStartIndices.has(slotIndex)
-        ) {
+        if (spanCoveredIndices.has(slotIndex) && !spanStartIndices.has(slotIndex)) {
           return null;
         }
 
@@ -660,10 +670,7 @@ function SlotList({
         }
 
         const timeId = myTimetable.formatTime(slot.startTime);
-        const timeText = myTimetable.formatTimeRange(
-          slot.startTime,
-          slot.endTime,
-        );
+        const timeText = myTimetable.formatTimeRange(slot.startTime, slot.endTime);
         const active = isSessionActive(timeId);
 
         if (slot.slotType === "shared") {
@@ -724,8 +731,7 @@ function IndividualSlotRow({
       <TimeSlot timeText={timeText} isActive={isActive} />
       {TRACK_KEYS.map((key) => {
         const content = slot.tracks[key];
-        const shouldAssignTourId =
-          isFirstSession && !tourIdAssigned && content.type === "session";
+        const shouldAssignTourId = isFirstSession && !tourIdAssigned && content.type === "session";
         if (shouldAssignTourId) tourIdAssigned = true;
         return (
           <TrackCell

--- a/src/components/talks/DayTimeTable/index.tsx
+++ b/src/components/talks/DayTimeTable/index.tsx
@@ -21,7 +21,11 @@ import type {
 } from "@/types/timetable-api";
 import { myTimetable } from "@/utils/myTimetable";
 
-function SlotTrackHeader({ track }: { track: TimetableResponse["tracks"][number] }) {
+function SlotTrackHeader({
+  track,
+}: {
+  track: TimetableResponse["tracks"][number];
+}) {
   const [copySuccess, setCopySuccess] = useState(false);
   const key = track.id as TrackKey;
   const style = TRACK_STYLE[key];
@@ -58,7 +62,13 @@ function SlotTrackHeader({ track }: { track: TimetableResponse["tracks"][number]
   );
 }
 
-function TimeSlot({ timeText, isActive = false }: { timeText: string; isActive?: boolean }) {
+function TimeSlot({
+  timeText,
+  isActive = false,
+}: {
+  timeText: string;
+  isActive?: boolean;
+}) {
   return (
     <div
       className={`relative flex flex-col gap-2 p-2 items-center justify-center text-center w-full h-full md:w-[99px] lg:w-[125px] ${
@@ -134,7 +144,9 @@ function TrackCell({
   const style = TRACK_STYLE[trackKey];
 
   if (content.type === "override") {
-    return <div className="bg-gray-50 px-5 h-16 flex items-center justify-center text-black-700" />;
+    return (
+      <div className="bg-gray-50 px-5 h-16 flex items-center justify-center text-black-700" />
+    );
   }
 
   if (content.type === "closed") {
@@ -180,7 +192,14 @@ function TrackCell({
     );
   }
 
-  return <SessionCell content={content} trackKey={trackKey} trackName={trackName} id={id} />;
+  return (
+    <SessionCell
+      content={content}
+      trackKey={trackKey}
+      trackName={trackName}
+      id={id}
+    />
+  );
 }
 
 function TriangleBadge({ cssVar }: { cssVar: string }) {
@@ -201,7 +220,11 @@ function TriangleBadge({ cssVar }: { cssVar: string }) {
   );
 }
 
-function SessionTypeLabel({ sessionType }: { sessionType: SessionTrack["sessionType"] }) {
+function SessionTypeLabel({
+  sessionType,
+}: {
+  sessionType: SessionTrack["sessionType"];
+}) {
   const { name, color } = TALK_TYPE[sessionType];
   return (
     <span
@@ -256,7 +279,10 @@ function SessionCell({
           const speakerName = master?.speaker.name ?? "";
           return (
             <div key={ref.id} className="flex flex-col gap-1">
-              <Link href={`/talks/${ref.id}`} className="underline hover:text-blue-purple-500">
+              <Link
+                href={`/talks/${ref.id}`}
+                className="underline hover:text-blue-purple-500"
+              >
                 <p className="text-[16px]">{title}</p>
               </Link>
               <div className="flex items-center gap-2">
@@ -308,7 +334,10 @@ function resolveSpanGroups(
 
 function buildSpanMap(resolved: ResolvedSpanGroup[]) {
   const hiddenCells = new Set<string>();
-  const spanCells = new Map<string, { rowSpan: number; label: string; link?: string }>();
+  const spanCells = new Map<
+    string,
+    { rowSpan: number; label: string; link?: string }
+  >();
 
   for (const group of resolved) {
     const rowSpan = group.slotIndexEnd - group.slotIndexStart + 1;
@@ -351,7 +380,10 @@ function SpanGroupSection({
   const group = resolvedSpanGroups.find((g) => g.slotIndexStart === startIndex);
   if (!group) return null;
 
-  const slotsInGroup = slots.slice(group.slotIndexStart, group.slotIndexEnd + 1);
+  const slotsInGroup = slots.slice(
+    group.slotIndexStart,
+    group.slotIndexEnd + 1,
+  );
   const totalRows = slotsInGroup.length;
 
   return (
@@ -361,7 +393,10 @@ function SpanGroupSection({
         {slotsInGroup.map((slot) => {
           if (slot.slotType !== "individual") return null;
           const timeId = myTimetable.formatTime(slot.startTime);
-          const timeText = myTimetable.formatTimeRange(slot.startTime, slot.endTime);
+          const timeText = myTimetable.formatTimeRange(
+            slot.startTime,
+            slot.endTime,
+          );
           const active = isSessionActiveFn(timeId);
 
           const hasSession =
@@ -393,7 +428,10 @@ function SpanGroupSection({
           if (slot.slotType !== "individual") return null;
           const idx = group.slotIndexStart + i;
           const timeId = myTimetable.formatTime(slot.startTime);
-          const timeText = myTimetable.formatTimeRange(slot.startTime, slot.endTime);
+          const timeText = myTimetable.formatTimeRange(
+            slot.startTime,
+            slot.endTime,
+          );
           const active = isSessionActiveFn(timeId);
 
           const hasSession =
@@ -419,7 +457,9 @@ function SpanGroupSection({
                 if (span) {
                   const spanContent = slot.tracks[key];
                   const spanSessionId =
-                    spanContent.type === "session" ? spanContent.sessions[0]?.id : undefined;
+                    spanContent.type === "session"
+                      ? spanContent.sessions[0]?.id
+                      : undefined;
                   return (
                     <div
                       key={key}
@@ -482,10 +522,11 @@ export function DayTimeTable({ data }: { data: TimetableResponse }) {
     [data.slots],
   );
 
-  const { showScrollButton, scrollToCurrentSession, isSessionActive } = useTimetable({
-    sessionTimeTable,
-    sessionElements: sessionRefs.current,
-  });
+  const { showScrollButton, scrollToCurrentSession, isSessionActive } =
+    useTimetable({
+      sessionTimeTable,
+      sessionElements: sessionRefs.current,
+    });
 
   const trackNames = useMemo(() => {
     const map: Record<string, string> = {};
@@ -593,7 +634,10 @@ function SlotList({
   return (
     <>
       {data.slots.map((slot, slotIndex) => {
-        if (spanCoveredIndices.has(slotIndex) && !spanStartIndices.has(slotIndex)) {
+        if (
+          spanCoveredIndices.has(slotIndex) &&
+          !spanStartIndices.has(slotIndex)
+        ) {
           return null;
         }
 
@@ -616,7 +660,10 @@ function SlotList({
         }
 
         const timeId = myTimetable.formatTime(slot.startTime);
-        const timeText = myTimetable.formatTimeRange(slot.startTime, slot.endTime);
+        const timeText = myTimetable.formatTimeRange(
+          slot.startTime,
+          slot.endTime,
+        );
         const active = isSessionActive(timeId);
 
         if (slot.slotType === "shared") {
@@ -677,7 +724,8 @@ function IndividualSlotRow({
       <TimeSlot timeText={timeText} isActive={isActive} />
       {TRACK_KEYS.map((key) => {
         const content = slot.tracks[key];
-        const shouldAssignTourId = isFirstSession && !tourIdAssigned && content.type === "session";
+        const shouldAssignTourId =
+          isFirstSession && !tourIdAssigned && content.type === "session";
         if (shouldAssignTourId) tourIdAssigned = true;
         return (
           <TrackCell

--- a/src/components/talks/DayTimeTable/index.tsx
+++ b/src/components/talks/DayTimeTable/index.tsx
@@ -21,7 +21,11 @@ import type {
 } from "@/types/timetable-api";
 import { myTimetable } from "@/utils/myTimetable";
 
-function SlotTrackHeader({ track }: { track: TimetableResponse["tracks"][number] }) {
+function SlotTrackHeader({
+  track,
+}: {
+  track: TimetableResponse["tracks"][number];
+}) {
   const [copySuccess, setCopySuccess] = useState(false);
   const key = track.id as TrackKey;
   const style = TRACK_STYLE[key];
@@ -58,7 +62,13 @@ function SlotTrackHeader({ track }: { track: TimetableResponse["tracks"][number]
   );
 }
 
-function TimeSlot({ timeText, isActive = false }: { timeText: string; isActive?: boolean }) {
+function TimeSlot({
+  timeText,
+  isActive = false,
+}: {
+  timeText: string;
+  isActive?: boolean;
+}) {
   return (
     <div
       className={`relative flex flex-col gap-2 p-2 items-center justify-center text-center w-full h-full md:w-[99px] lg:w-[125px] ${
@@ -134,7 +144,9 @@ function TrackCell({
   const style = TRACK_STYLE[trackKey];
 
   if (content.type === "override") {
-    return <div className="bg-gray-50 px-5 h-16 flex items-center justify-center text-black-700" />;
+    return (
+      <div className="bg-gray-50 px-5 h-16 flex items-center justify-center text-black-700" />
+    );
   }
 
   if (content.type === "closed") {
@@ -180,7 +192,14 @@ function TrackCell({
     );
   }
 
-  return <SessionCell content={content} trackKey={trackKey} trackName={trackName} id={id} />;
+  return (
+    <SessionCell
+      content={content}
+      trackKey={trackKey}
+      trackName={trackName}
+      id={id}
+    />
+  );
 }
 
 function SpanCell({
@@ -247,7 +266,11 @@ function TriangleBadge({ cssVar }: { cssVar: string }) {
   );
 }
 
-function SessionTypeLabel({ sessionType }: { sessionType: SessionTrack["sessionType"] }) {
+function SessionTypeLabel({
+  sessionType,
+}: {
+  sessionType: SessionTrack["sessionType"];
+}) {
   const { name, color } = TALK_TYPE[sessionType];
   return (
     <span
@@ -302,7 +325,10 @@ function SessionCell({
           const speakerName = master?.speaker.name ?? "";
           return (
             <div key={ref.id} className="flex flex-col gap-1">
-              <Link href={`/talks/${ref.id}`} className="underline hover:text-blue-purple-500">
+              <Link
+                href={`/talks/${ref.id}`}
+                className="underline hover:text-blue-purple-500"
+              >
                 <p className="text-[16px]">{title}</p>
               </Link>
               <div className="flex items-center gap-2">
@@ -354,7 +380,10 @@ function resolveSpanGroups(
 
 function buildSpanMap(resolved: ResolvedSpanGroup[]) {
   const hiddenCells = new Set<string>();
-  const spanCells = new Map<string, { rowSpan: number; label: string; link?: string }>();
+  const spanCells = new Map<
+    string,
+    { rowSpan: number; label: string; link?: string }
+  >();
 
   for (const group of resolved) {
     const rowSpan = group.slotIndexEnd - group.slotIndexStart + 1;
@@ -397,7 +426,10 @@ function SpanGroupSection({
   const group = resolvedSpanGroups.find((g) => g.slotIndexStart === startIndex);
   if (!group) return null;
 
-  const slotsInGroup = slots.slice(group.slotIndexStart, group.slotIndexEnd + 1);
+  const slotsInGroup = slots.slice(
+    group.slotIndexStart,
+    group.slotIndexEnd + 1,
+  );
   const totalRows = slotsInGroup.length;
 
   return (
@@ -408,7 +440,10 @@ function SpanGroupSection({
           if (slot.slotType !== "individual") return null;
           const idx = group.slotIndexStart + i;
           const timeId = myTimetable.formatTime(slot.startTime);
-          const timeText = myTimetable.formatTimeRange(slot.startTime, slot.endTime);
+          const timeText = myTimetable.formatTimeRange(
+            slot.startTime,
+            slot.endTime,
+          );
           const active = isSessionActiveFn(timeId);
 
           const hasSession =
@@ -469,7 +504,10 @@ function SpanGroupSection({
           if (slot.slotType !== "individual") return null;
           const idx = group.slotIndexStart + i;
           const timeId = myTimetable.formatTime(slot.startTime);
-          const timeText = myTimetable.formatTimeRange(slot.startTime, slot.endTime);
+          const timeText = myTimetable.formatTimeRange(
+            slot.startTime,
+            slot.endTime,
+          );
           const active = isSessionActiveFn(timeId);
 
           const hasSession =
@@ -536,10 +574,11 @@ export function DayTimeTable({ data }: { data: TimetableResponse }) {
     [data.slots],
   );
 
-  const { showScrollButton, scrollToCurrentSession, isSessionActive } = useTimetable({
-    sessionTimeTable,
-    sessionElements: sessionRefs.current,
-  });
+  const { showScrollButton, scrollToCurrentSession, isSessionActive } =
+    useTimetable({
+      sessionTimeTable,
+      sessionElements: sessionRefs.current,
+    });
 
   const trackNames = useMemo(() => {
     const map: Record<string, string> = {};
@@ -647,7 +686,10 @@ function SlotList({
   return (
     <>
       {data.slots.map((slot, slotIndex) => {
-        if (spanCoveredIndices.has(slotIndex) && !spanStartIndices.has(slotIndex)) {
+        if (
+          spanCoveredIndices.has(slotIndex) &&
+          !spanStartIndices.has(slotIndex)
+        ) {
           return null;
         }
 
@@ -670,7 +712,10 @@ function SlotList({
         }
 
         const timeId = myTimetable.formatTime(slot.startTime);
-        const timeText = myTimetable.formatTimeRange(slot.startTime, slot.endTime);
+        const timeText = myTimetable.formatTimeRange(
+          slot.startTime,
+          slot.endTime,
+        );
         const active = isSessionActive(timeId);
 
         if (slot.slotType === "shared") {
@@ -731,7 +776,8 @@ function IndividualSlotRow({
       <TimeSlot timeText={timeText} isActive={isActive} />
       {TRACK_KEYS.map((key) => {
         const content = slot.tracks[key];
-        const shouldAssignTourId = isFirstSession && !tourIdAssigned && content.type === "session";
+        const shouldAssignTourId =
+          isFirstSession && !tourIdAssigned && content.type === "session";
         if (shouldAssignTourId) tourIdAssigned = true;
         return (
           <TrackCell

--- a/src/constants/timetable/timetable.ts
+++ b/src/constants/timetable/timetable.ts
@@ -442,12 +442,24 @@ const day2: TimetableResponse = {
         LEVERAGES: {
           type: "session",
           sessionType: "SPONSOR",
-          sessions: [{ id: "79" }, { id: "77" }, { id: "83" }, { id: "81" }, { id: "85" }],
+          sessions: [
+            { id: "79" },
+            { id: "77" },
+            { id: "83" },
+            { id: "81" },
+            { id: "85" },
+          ],
         },
         UPSIDER: {
           type: "session",
           sessionType: "SPONSOR",
-          sessions: [{ id: "82" }, { id: "80" }, { id: "78" }, { id: "86" }, { id: "84" }],
+          sessions: [
+            { id: "82" },
+            { id: "80" },
+            { id: "78" },
+            { id: "86" },
+            { id: "84" },
+          ],
         },
         RIGHTTOUCH: { type: "other", label: "ランチ" },
       },

--- a/src/constants/timetable/timetable.ts
+++ b/src/constants/timetable/timetable.ts
@@ -338,6 +338,7 @@ const day1: TimetableResponse = {
       label: "ハンズオン",
       startTime: d1(13, 40),
       endTime: d1(15, 40),
+      link: "https://typescript-jpc.connpass.com/event/392953/",
     },
   ],
 };
@@ -441,24 +442,12 @@ const day2: TimetableResponse = {
         LEVERAGES: {
           type: "session",
           sessionType: "SPONSOR",
-          sessions: [
-            { id: "79" },
-            { id: "77" },
-            { id: "83" },
-            { id: "81" },
-            { id: "85" },
-          ],
+          sessions: [{ id: "79" }, { id: "77" }, { id: "83" }, { id: "81" }, { id: "85" }],
         },
         UPSIDER: {
           type: "session",
           sessionType: "SPONSOR",
-          sessions: [
-            { id: "82" },
-            { id: "80" },
-            { id: "78" },
-            { id: "86" },
-            { id: "84" },
-          ],
+          sessions: [{ id: "82" }, { id: "80" }, { id: "78" }, { id: "86" }, { id: "84" }],
         },
         RIGHTTOUCH: { type: "other", label: "ランチ" },
       },

--- a/src/types/timetable-api.ts
+++ b/src/types/timetable-api.ts
@@ -51,11 +51,7 @@ export type SessionTrack = {
   sessions: SessionRef[];
 };
 
-export type TrackContent =
-  | ClosedTrack
-  | OtherTrack
-  | OverrideTrack
-  | SessionTrack;
+export type TrackContent = ClosedTrack | OtherTrack | OverrideTrack | SessionTrack;
 
 export type SharedSlot = {
   slotType: "shared";
@@ -78,6 +74,7 @@ export type SpanGroup = {
   label: string;
   startTime: number;
   endTime: number;
+  link?: string;
 };
 
 export type EventDate = "Day1" | "Day2";

--- a/src/types/timetable-api.ts
+++ b/src/types/timetable-api.ts
@@ -51,7 +51,11 @@ export type SessionTrack = {
   sessions: SessionRef[];
 };
 
-export type TrackContent = ClosedTrack | OtherTrack | OverrideTrack | SessionTrack;
+export type TrackContent =
+  | ClosedTrack
+  | OtherTrack
+  | OverrideTrack
+  | SessionTrack;
 
 export type SharedSlot = {
   slotType: "shared";


### PR DESCRIPTION
## Summary
- Day1タイムテーブルのハンズオン（SpanGroup）にconnpassイベントページ（ https://typescript-jpc.connpass.com/event/392953/ ）へのリンクを追加
- `SpanGroup`型にoptionalな`link`フィールドを追加し、デスクトップ表示のspan cellでリンクとして描画

## Test plan
- [x] デスクトップ表示でDay1タイムテーブルの「ハンズオン」がリンクになっていることを確認
- [x] リンクをクリックするとconnpassページが新タブで開くことを確認
- [ ] モバイル表示でタイムテーブルが正常に表示されることを確認
- [x] Day2のタイムテーブルに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)