### PR TITLE
feat: マイタイムテーブルのデザイン調整

### DIFF
--- a/src/app/talks/me/MyTimetablePage.tsx
+++ b/src/app/talks/me/MyTimetablePage.tsx
@@ -577,7 +577,7 @@ function TalkSearchPanel({
       <div
         id="tour-search-panel"
         ref={popupRef}
-        className="relative w-[220px] max-w-full sm:w-full sm:max-w-md"
+        className="relative w-[208px] max-w-full sm:w-full sm:max-w-md"
       >
         <div className="relative">
           <Search

--- a/src/app/talks/me/MyTimetablePage.tsx
+++ b/src/app/talks/me/MyTimetablePage.tsx
@@ -180,7 +180,7 @@ function TimePickerDialog({
         </button>
       </div>
 
-      <div className="mt-3 max-h-72 overflow-y-auto flex flex-col gap-2">
+      <div className="mt-3 max-h-80 overflow-y-auto flex flex-col gap-2">
         {pickableByTime.length === 0 ? (
           <p className="text-sm text-black-500">該当するトークがありません。</p>
         ) : (

--- a/src/app/talks/me/MyTimetablePage.tsx
+++ b/src/app/talks/me/MyTimetablePage.tsx
@@ -22,7 +22,12 @@ import {
 import { StartTourButton } from "@/components/talks/Tour";
 import { Button } from "@/components/ui/button";
 import { showAppToast } from "@/components/ui/GlobalToast";
-import { TRACK, TRACK_STYLE } from "@/constants/timetable";
+import {
+  TALK_TYPE,
+  TRACK,
+  TRACK_KEYS,
+  TRACK_STYLE,
+} from "@/constants/timetable";
 import type { EventDate } from "@/types/timetable-api";
 import { Input } from "@/ui/input";
 import {
@@ -67,11 +72,13 @@ function TalkSelectItem({
   talk,
   isAdded,
   metaClassName,
+  showSessionType = false,
   onClick,
 }: {
   talk: TalkWithMinutes;
   isAdded: boolean;
   metaClassName?: string;
+  showSessionType?: boolean;
   onClick: () => void;
 }) {
   return (
@@ -95,7 +102,17 @@ function TalkSelectItem({
         )}
       </div>
       <p className="py-1 text-sm font-bold">{talk.title}</p>
-      <p className="text-xs">{talk.speaker.name}</p>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <p className="text-xs">{talk.speaker.name}</p>
+        {showSessionType && (
+          <span
+            className="rounded-full px-1.5 py-0.5 text-[10px] font-bold text-white"
+            style={{ backgroundColor: TALK_TYPE[talk.sessionType].color }}
+          >
+            {TALK_TYPE[talk.sessionType].name}
+          </span>
+        )}
+      </div>
     </button>
   );
 }
@@ -136,6 +153,15 @@ function TimePickerDialog({
     [allTalks, timePickerState],
   );
 
+  const groupedTalks = useMemo(
+    () =>
+      TRACK_KEYS.map((track) => ({
+        track,
+        talks: pickableByTime.filter((talk) => talk.track === track),
+      })).filter((group) => group.talks.length > 0),
+    [pickableByTime],
+  );
+
   return (
     <DialogOverlay onClose={onClose}>
       <div className="flex items-center justify-between gap-2">
@@ -158,17 +184,39 @@ function TimePickerDialog({
         {pickableByTime.length === 0 ? (
           <p className="text-sm text-black-500">該当するトークがありません。</p>
         ) : (
-          pickableByTime.map((talk) => {
-            const isAdded = selectedIds.includes(talk.id);
-            return (
-              <TalkSelectItem
-                key={`pick-time-${talk.id}`}
-                talk={talk}
-                isAdded={isAdded}
-                onClick={() => (isAdded ? onRemove(talk.id) : onAdd(talk.id))}
-              />
-            );
-          })
+          groupedTalks.map((group) => (
+            <section
+              key={`pick-track-${group.track}`}
+              className="rounded-lg border border-black-200 bg-black-50/50 p-2"
+            >
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`h-2.5 w-2.5 rounded-full ${TRACK_STYLE[group.track].bg}`}
+                  />
+                  <h4 className="text-sm font-bold text-black-700">
+                    {TRACK[group.track].name}
+                  </h4>
+                </div>
+              </div>
+              <div className="flex flex-col gap-2">
+                {group.talks.map((talk) => {
+                  const isAdded = selectedIds.includes(talk.id);
+                  return (
+                    <TalkSelectItem
+                      key={`pick-time-${talk.id}`}
+                      talk={talk}
+                      isAdded={isAdded}
+                      showSessionType
+                      onClick={() =>
+                        isAdded ? onRemove(talk.id) : onAdd(talk.id)
+                      }
+                    />
+                  );
+                })}
+              </div>
+            </section>
+          ))
         )}
       </div>
     </DialogOverlay>

--- a/src/components/talks/TimelineColumn/index.tsx
+++ b/src/components/talks/TimelineColumn/index.tsx
@@ -141,35 +141,33 @@ export function TimelineColumn({
 
       {/* セッション時間枠だが、この日には選択できるトークがない領域 */}
       {editable &&
-        MY_TIMETABLE_CONST.TIMELINE_SEGMENTS.filter(
-          (seg) =>
-            seg.type === "session" &&
-            !myTimetable.hasSessionInSlot(eventDate, seg.start, seg.end),
-        ).map((seg) => {
-          const label =
-            eventDate === "Day2" && seg.start >= 1040
-              ? "OST / 懇親会"
-              : "セッションなし";
-          return (
-            <div
-              key={`${eventDate}-empty-session-${seg.start}`}
-              aria-hidden="true"
-              className="absolute left-0 right-0 z-0 flex items-center justify-center overflow-hidden bg-black-100/65 text-xs font-bold text-black-500"
-              style={{ top: `${seg.top}px`, height: `${seg.height}px` }}
-            >
+        MY_TIMETABLE_CONST.TIMELINE_BY_DAY[eventDate].segments
+          .filter(
+            (seg) =>
+              seg.type === "session" &&
+              !myTimetable.hasSessionInSlot(eventDate, seg.start, seg.end),
+          )
+          .map((seg) => {
+            return (
               <div
-                className="absolute inset-0 opacity-70"
-                style={{
-                  backgroundImage:
-                    "repeating-linear-gradient(-45deg, rgba(91, 100, 124, 0.16) 0 8px, transparent 8px 16px)",
-                }}
-              />
-              <span className="relative z-10 rounded-full border border-black-300 bg-white/85 px-3 py-1 shadow-sm">
-                {label}
-              </span>
-            </div>
-          );
-        })}
+                key={`${eventDate}-empty-session-${seg.start}`}
+                aria-hidden="true"
+                className="absolute left-0 right-0 z-0 flex items-center justify-center overflow-hidden bg-black-100/65 text-xs font-bold text-black-500"
+                style={{ top: `${seg.top}px`, height: `${seg.height}px` }}
+              >
+                <div
+                  className="absolute inset-0 opacity-70"
+                  style={{
+                    backgroundImage:
+                      "repeating-linear-gradient(-45deg, rgba(91, 100, 124, 0.16) 0 8px, transparent 8px 16px)",
+                  }}
+                />
+                <span className="relative z-10 rounded-full border border-black-300 bg-white/85 px-3 py-1 shadow-sm">
+                  セッションなし
+                </span>
+              </div>
+            );
+          })}
 
       {/* セグメント境界線（各セグメントの上端＋下端、重複排除、最上端・最下端は除外） */}
       {[

--- a/src/components/talks/TimelineColumn/index.tsx
+++ b/src/components/talks/TimelineColumn/index.tsx
@@ -139,6 +139,38 @@ export function TimelineColumn({
             />
           ))}
 
+      {/* セッション時間枠だが、この日には選択できるトークがない領域 */}
+      {editable &&
+        MY_TIMETABLE_CONST.TIMELINE_SEGMENTS.filter(
+          (seg) =>
+            seg.type === "session" &&
+            !myTimetable.hasSessionInSlot(eventDate, seg.start, seg.end),
+        ).map((seg) => {
+          const label =
+            eventDate === "Day2" && seg.start >= 1040
+              ? "OST / 懇親会"
+              : "セッションなし";
+          return (
+            <div
+              key={`${eventDate}-empty-session-${seg.start}`}
+              aria-hidden="true"
+              className="absolute left-0 right-0 z-0 flex items-center justify-center overflow-hidden bg-black-100/65 text-xs font-bold text-black-500"
+              style={{ top: `${seg.top}px`, height: `${seg.height}px` }}
+            >
+              <div
+                className="absolute inset-0 opacity-70"
+                style={{
+                  backgroundImage:
+                    "repeating-linear-gradient(-45deg, rgba(91, 100, 124, 0.16) 0 8px, transparent 8px 16px)",
+                }}
+              />
+              <span className="relative z-10 rounded-full border border-black-300 bg-white/85 px-3 py-1 shadow-sm">
+                {label}
+              </span>
+            </div>
+          );
+        })}
+
       {/* セグメント境界線（各セグメントの上端＋下端、重複排除、最上端・最下端は除外） */}
       {[
         ...new Set(

--- a/src/constants/timetable/talkList.ts
+++ b/src/constants/timetable/talkList.ts
@@ -67,6 +67,7 @@ function resolveSession(id: string): SessionSummary {
 
 export type Talk = SessionSummary & {
   eventDate: EventDate;
+  sessionType: SessionKey;
   track: TrackKey;
   time: string;
 };
@@ -74,12 +75,13 @@ export type Talk = SessionSummary & {
 export const talkList: Talk[] = timetableList.flatMap((day) =>
   day.cells.flatMap((cell) => {
     if (cell.content.type !== "session") return [];
-    const { sessions } = cell.content;
+    const { sessions, sessionType } = cell.content;
     const time = myTimetable.formatTimeRange(cell.startTime, cell.endTime);
     return cell.trackKeys.flatMap((trackKey) =>
       sessions.map((ref) => ({
         ...resolveSession(ref.id),
         eventDate: day.day,
+        sessionType,
         track: trackKey,
         time,
       })),


### PR DESCRIPTION
# 変更内容

## セッションが選択できない時間帯をわかりやすく表示

<img width="784" height="1370" alt="image" src="https://github.com/user-attachments/assets/7d192458-3920-4e32-8671-e4bbc96875c3" />

## セッション選択ダイアログの表示を調整

|||
|---|---|
|<img width="770" height="1368" alt="image" src="https://github.com/user-attachments/assets/ec1c0b1a-5aad-423c-a4db-d0a26886c834" />|<img width="778" height="1370" alt="screenshot 2026-05-14 19 29 49" src="https://github.com/user-attachments/assets/abd69138-cd76-43d9-923c-ee95bf9af755" />|
