### PR TITLE
fix: workflow 経由で動作するActionsが失敗していた問題を修正

### DIFF
--- a/.github/workflows/add-side-event.yml
+++ b/.github/workflows/add-side-event.yml
@@ -65,7 +65,9 @@ jobs:
           pnpm biome check --write src/constants/sideEventList.ts || true
 
       - name: TypeScript check
-        run: pnpm typecheck
+        run: |
+          pnpm -s generate:staff-list
+          pnpm typecheck
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6

--- a/.github/workflows/add-staff.yml
+++ b/.github/workflows/add-staff.yml
@@ -61,7 +61,9 @@ jobs:
           pnpm biome check --write src/constants/staff/* || true
 
       - name: TypeScript check
-        run: pnpm typecheck
+        run: |
+          pnpm -s generate:staff-list  
+          pnpm typecheck
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
`pnpm dev` `pnpm build` 時に自動生成する staff-list ファイルが、これらの Actions で typecheck するときにはなかったため、エラーになっていました。

`pnpm typecheck` する前に再生成するようにしました