### PR TITLE
fix: generate後にstaff.generated.tsをbiomeでフォーマット

### DIFF
--- a/.github/workflows/add-day-staff.yml
+++ b/.github/workflows/add-day-staff.yml
@@ -63,6 +63,7 @@ jobs:
       - name: TypeScript check
         run: |
           pnpm -s generate:staff-list
+          pnpm biome format --write src/constants/day-staff.generated.ts
           pnpm typecheck
 
       - name: Create Pull Request

--- a/.github/workflows/add-staff.yml
+++ b/.github/workflows/add-staff.yml
@@ -62,7 +62,8 @@ jobs:
 
       - name: TypeScript check
         run: |
-          pnpm -s generate:staff-list  
+          pnpm -s generate:staff-list
+          pnpm biome format --write src/constants/staff.generated.ts
           pnpm typecheck
 
       - name: Create Pull Request


### PR DESCRIPTION
## 原因

`generate:staff-list` で生成した `*.generated.ts` を Biome でフォーマットしていなかったため、エントリ数によっては CI の Biome チェックでフォーマット差分エラーが発生していました。

具体的には、1件だけ追加した場合に生成スクリプトは複数行で出力しますが、Biome は1件なら1行にするため差分が出ます：

\`\`\`diff
- export const DAY_STAFF_LIST: DayStaff[] = [
-   dayStaff27627295,
- ];
+ export const DAY_STAFF_LIST: DayStaff[] = [dayStaff27627295];
\`\`\`

## 修正

`add-staff.yml` / `add-day-staff.yml` の TypeScript check ステップで、`generate:staff-list` 実行後に `biome format --write` を追加。

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)