### PR TITLE
fix: code-quality.yml で生成ファイルをbiomeフォーマット後にCI実行

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           version: latest
 
+      - name: Format generated files
+        run: biome format --write src/constants/staff.generated.ts src/constants/day-staff.generated.ts
+
       - name: Run Biome
         run: biome ci ./src/
 


### PR DESCRIPTION
## 原因

`code-quality.yml` が `pnpm generate:staff-list` で `*.generated.ts` を再生成した後、Biome フォーマットをかけずに `biome ci` に渡していました。

生成スクリプトが出す配列フォーマット（複数行）と Biome が期待するフォーマット（1件なら1行）が一致しないため、当日スタッフ・スタッフを追加した直後のPRで毎回CIエラーになっていました。

## 修正

Biome setup の直後に `biome format --write` で生成ファイルを整形してから `biome ci` を実行するステップを追加。

\`\`\`yaml
- name: Format generated files
  run: biome format --write src/constants/staff.generated.ts src/constants/day-staff.generated.ts
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)