### PR TITLE
feat: 会場インフォメーションページのランチセクションに内容を追加

### DIFF
--- a/src/app/onsite/page.tsx
+++ b/src/app/onsite/page.tsx
@@ -122,6 +122,17 @@ export default function OnsitePage() {
           <h2 className="text-xl font-bold text-blue-light-500 md:text-2xl">
             ランチ
           </h2>
+          <ul className="flex flex-col gap-4 list-disc list-outside pl-5">
+            <li>
+              レバレジーズトラック後方・UPSIDERトラック後方・休憩ルーム内でお弁当または食券（ランチチケット）を配布します。
+            </li>
+            <li>
+              お弁当は各セッションルームまたは休憩ルーム内でお召し上がりいただけます。
+            </li>
+            <li>
+              食券（ランチチケット）は会場外のグランドホワイエ内の飲食店でご利用いただけます。詳しくは券面に記載のQRコードからご確認ください。
+            </li>
+          </ul>
         </section>
       </div>
     </main>


### PR DESCRIPTION
## Summary

- 会場インフォメーションページ (`/onsite`) のランチセクションに配布・利用方法の説明を追加
- お弁当・食券（ランチチケット）の配布場所、食事場所、食券利用方法の3項目をリスト形式で表示

## Test plan

- [ ] `/onsite` ページでランチセクションが正しく表示されること
- [ ] 箇条書きリストが他のセクションのスタイルと統一されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)