### PR TITLE
スポンサー情報の取得をAPI経由ではなくjsonファイルからの取得に変更

### DIFF
--- a/src/lib/fetch-sponsors.ts
+++ b/src/lib/fetch-sponsors.ts
@@ -1,25 +1,15 @@
+import sponsorsData from "@/constants/sponsors.json";
 import type {
   GroupedSponsors,
   SponsorApiResponse,
   SponsorPlan,
 } from "@/types/sponsor-api";
 
-const SPONSORS_API_URL =
-  "https://tskaigi-cms.system-admin-df1.workers.dev/api/sponsors";
-
 const SPONSOR_PLANS: SponsorPlan[] = ["platinum", "gold", "silver", "bronze"];
 
+const sponsors = sponsorsData as SponsorApiResponse[];
+
 export async function fetchSponsors(): Promise<GroupedSponsors> {
-  const response = await fetch(SPONSORS_API_URL, {
-    next: { revalidate: 3600 }, // 1時間ごとに再検証
-  });
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch sponsors: ${response.statusText}`);
-  }
-
-  const sponsors: SponsorApiResponse[] = await response.json();
-
   const grouped: GroupedSponsors = {
     platinum: [],
     gold: [],
@@ -39,15 +29,11 @@ export async function fetchSponsors(): Promise<GroupedSponsors> {
 }
 
 export async function fetchSponsor(slug: string): Promise<SponsorApiResponse> {
-  const response = await fetch(`${SPONSORS_API_URL}/${slug}`, {
-    next: { revalidate: 3600 }, // 1時間ごとに再検証
-  });
+  const sponsor = sponsors.find((s) => s.slug === slug);
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch sponsors: ${response.statusText}`);
+  if (!sponsor) {
+    throw new Error(`Sponsor not found: ${slug}`);
   }
-
-  const sponsor: SponsorApiResponse = await response.json();
 
   return sponsor;
 }


### PR DESCRIPTION
close: #277 

#349 で追加したデータを利用して、APIを叩かずにスポンサー情報を表示するように変更いたしました。

ざっとではありますが、ローカルと本番で見比べて問題無さそうなことを確認しました。

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4fcfcf70-149d-4cd7-869f-0da1d60bd5cc" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/27b339d9-09e8-4907-bc14-01be27b8dc35" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4ba75d3d-04db-42da-9555-49dd83010874" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bfae8628-831a-47b6-ba72-0413d7b9f0be" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bc101a53-6699-4232-8dfc-e9d93e059c88" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f46ea95f-551d-466a-ae25-94f0fc154d0f" />
