### PR TITLE
feat: マイタイムテーブル周りの挙動を調整

### DIFF
--- a/src/app/talks/[id]/TalkContent.tsx
+++ b/src/app/talks/[id]/TalkContent.tsx
@@ -246,7 +246,10 @@ export function TalkContent({
           </div>
         </div>
       </div>
-      <div className="fixed bottom-6 right-6 z-50 flex gap-2">
+      <div
+        className="fixed right-6 z-50 flex gap-2"
+        style={{ bottom: "calc(env(safe-area-inset-bottom) + 1.5rem)" }}
+      >
         <FloatingNavButtons />
       </div>
     </main>

--- a/src/app/talks/me/MyTimetablePage.tsx
+++ b/src/app/talks/me/MyTimetablePage.tsx
@@ -51,8 +51,17 @@ function DialogOverlay({
   maxWidth?: string;
   onClose: () => void;
 }) {
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, []);
+
   return (
-    <div className="fixed inset-0 z-50 bg-black/30 p-4 flex items-center justify-center">
+    <div className="fixed inset-0 z-60 flex items-center justify-center bg-black/30 p-4">
       <button
         type="button"
         className="absolute inset-0"
@@ -62,7 +71,7 @@ function DialogOverlay({
       <section
         role="dialog"
         aria-modal="true"
-        className={`relative z-10 w-full ${maxWidth} rounded-xl bg-white p-4 md:p-6`}
+        className={`relative z-10 max-h-full w-full overflow-y-auto overscroll-none ${maxWidth} rounded-xl bg-white p-4 md:p-6`}
       >
         {children}
       </section>
@@ -269,45 +278,47 @@ function OverlapDialog({
 }) {
   return (
     <DialogOverlay onClose={onClose}>
-      <div className="flex items-start gap-2">
-        <AlertTriangle size={18} className="mt-0.5 text-orange-600" />
-        <div>
-          <h3 className="text-base font-bold text-black-700">
-            時間が重複しています
-          </h3>
-          <p className="mt-1 text-sm text-black-500">
-            追加候補: {overlapState.targetTalk.time} /{" "}
-            {overlapState.targetTalk.title}
-          </p>
+      <div className="flex max-h-[calc(100dvh-8rem)] flex-col">
+        <div className="shrink-0 flex items-start gap-2">
+          <AlertTriangle size={18} className="mt-0.5 text-orange-600" />
+          <div>
+            <h3 className="text-base font-bold text-black-700">
+              時間が重複しています
+            </h3>
+            <p className="mt-1 text-sm text-black-500">
+              追加候補: {overlapState.targetTalk.time} /{" "}
+              {overlapState.targetTalk.title}
+            </p>
+          </div>
         </div>
-      </div>
 
-      <div className="mt-4 rounded-lg border border-black-300 p-3">
-        <p className="text-sm font-bold">重複中のトーク</p>
-        <div className="mt-2 flex flex-col gap-2">
-          {overlapState.overlaps.map((talk) => (
-            <div
-              key={`overlap-${talk.id}`}
-              className="rounded border border-black-200 p-2"
-            >
-              <span className="text-sm">
-                <span className="block text-black-500 text-xs">
-                  {talk.time}
+        <div className="mt-4 min-h-0 flex-1 overflow-y-auto rounded-lg border border-black-300 p-3">
+          <p className="text-sm font-bold">重複中のトーク</p>
+          <div className="mt-2 flex flex-col gap-2">
+            {overlapState.overlaps.map((talk) => (
+              <div
+                key={`overlap-${talk.id}`}
+                className="rounded border border-black-200 p-2"
+              >
+                <span className="text-sm">
+                  <span className="block text-black-500 text-xs">
+                    {talk.time}
+                  </span>
+                  <span className="block font-bold">{talk.title}</span>
                 </span>
-                <span className="block font-bold">{talk.title}</span>
-              </span>
-            </div>
-          ))}
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
 
-      <div className="mt-4 flex flex-wrap justify-end gap-2">
-        <Button type="button" variant="outline" onClick={onClose}>
-          キャンセル
-        </Button>
-        <Button type="button" onClick={onResolve}>
-          重複したまま追加
-        </Button>
+        <div className="mt-4 shrink-0 flex flex-wrap justify-end gap-2">
+          <Button type="button" variant="outline" onClick={onClose}>
+            キャンセル
+          </Button>
+          <Button type="button" onClick={onResolve}>
+            重複したまま追加
+          </Button>
+        </div>
       </div>
     </DialogOverlay>
   );
@@ -525,6 +536,8 @@ export default function MyTimetablePage() {
   const [currentEventDate, setCurrentEventDate] = useState<EventDate>("Day1");
   const [timePickerState, setTimePickerState] = useState<TimePickerState>(null);
   const [overlapState, setOverlapState] = useState<OverlapState>(null);
+  const [overlapReturnState, setOverlapReturnState] =
+    useState<TimePickerState>(null);
   const [isClearConfirmOpen, setIsClearConfirmOpen] = useState(false);
   const [isQrOpen, setIsQrOpen] = useState(false);
   const [drawerTalk, setDrawerTalk] = useState<TalkWithMinutes | null>(null);
@@ -576,6 +589,7 @@ export default function MyTimetablePage() {
 
     if (hasCrossTrackOverlap) {
       setOverlapState({ targetTalk, overlaps: uniqueOverlaps });
+      setOverlapReturnState(timePickerState);
       setTimePickerState(null);
       return;
     }
@@ -607,7 +621,14 @@ export default function MyTimetablePage() {
     myTimetableIds.write(next);
     window.dispatchEvent(new Event("my-timetable-updated"));
     setOverlapState(null);
+    setOverlapReturnState(null);
     showAppToast("マイタイムテーブルに追加しました");
+  };
+
+  const closeOverlapDialog = () => {
+    setOverlapState(null);
+    setTimePickerState(overlapReturnState);
+    setOverlapReturnState(null);
   };
 
   const removeTalk = (id: string) => {
@@ -761,7 +782,7 @@ export default function MyTimetablePage() {
         <OverlapDialog
           overlapState={overlapState}
           onResolve={resolveOverlapAndAdd}
-          onClose={() => setOverlapState(null)}
+          onClose={closeOverlapDialog}
         />
       )}
 

--- a/src/app/talks/me/MyTimetablePage.tsx
+++ b/src/app/talks/me/MyTimetablePage.tsx
@@ -780,7 +780,10 @@ export default function MyTimetablePage() {
         />
       )}
 
-      <div className="fixed bottom-6 right-6 z-50">
+      <div
+        className="fixed right-6 z-50"
+        style={{ bottom: "calc(env(safe-area-inset-bottom) + 1.5rem)" }}
+      >
         <FloatingNavButtons />
       </div>
 

--- a/src/app/talks/page.tsx
+++ b/src/app/talks/page.tsx
@@ -80,7 +80,10 @@ const TalksPage = () => {
           />
         </div>
       </div>
-      <div className="fixed bottom-6 right-6 z-50 flex flex-col items-end gap-2">
+      <div
+        className="fixed right-6 z-50 flex flex-col items-end gap-2"
+        style={{ bottom: "calc(env(safe-area-inset-bottom) + 1.5rem)" }}
+      >
         {scrollState.showScrollButton && (
           <Button
             type="button"

--- a/src/app/talks/your/YourTimetablePage.tsx
+++ b/src/app/talks/your/YourTimetablePage.tsx
@@ -139,7 +139,10 @@ export default function YourTimetablePage() {
         />
       )}
 
-      <div className="fixed bottom-6 right-6 z-50 flex gap-2">
+      <div
+        className="fixed right-6 z-50 flex gap-2"
+        style={{ bottom: "calc(env(safe-area-inset-bottom) + 1.5rem)" }}
+      >
         <FloatingNavButtons />
       </div>
     </main>

--- a/src/components/talks/MyTimetableQrDialog/index.tsx
+++ b/src/components/talks/MyTimetableQrDialog/index.tsx
@@ -2,7 +2,7 @@
 
 import { X } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 type QrTab = "sync" | "share";
 
@@ -17,6 +17,15 @@ export function MyTimetableQrDialog({
 }) {
   const [activeTab, setActiveTab] = useState<QrTab>("sync");
 
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, []);
+
   const tabs: { key: QrTab; label: string }[] = [
     { key: "sync", label: "同期用" },
     { key: "share", label: "共有用" },
@@ -29,7 +38,7 @@ export function MyTimetableQrDialog({
       : "読み取った端末に保存されているマイタイムテーブル情報は上書きされません";
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/30 p-4 flex items-center justify-center">
+    <div className="fixed inset-0 z-60 bg-black/30 p-4 flex items-center justify-center">
       <button
         type="button"
         className="absolute inset-0"
@@ -39,7 +48,7 @@ export function MyTimetableQrDialog({
       <section
         role="dialog"
         aria-modal="true"
-        className="relative z-10 w-full max-w-sm rounded-xl bg-white p-4 md:p-6"
+        className="relative z-10 w-full max-w-sm overflow-y-auto overscroll-none rounded-xl bg-white p-4 md:p-6"
       >
         <div className="flex items-center justify-between">
           <h3 className="text-base font-bold text-black-700">QRコード</h3>

--- a/src/components/talks/Tour/TourOverlay.tsx
+++ b/src/components/talks/Tour/TourOverlay.tsx
@@ -671,6 +671,17 @@ export function TourOverlay() {
   const renderedStep = steps?.[currentStep];
   const renderedIsDialogMode = renderedStep?.selector === "#tour-dialog";
 
+  useEffect(() => {
+    if (!isOnbordaVisible || !renderedIsDialogMode) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOnbordaVisible, renderedIsDialogMode]);
+
   useLayoutEffect(() => {
     if (!isOnbordaVisible || renderedIsDialogMode) return;
     const card = cardRef.current;
@@ -794,11 +805,11 @@ export function TourOverlay() {
       <>
         <button
           type="button"
-          className="fixed inset-0 z-[900] cursor-default bg-black/50"
+          className="fixed inset-0 z-900 cursor-default bg-black/50"
           onClick={closeOnborda}
           aria-label="ツアーを閉じる"
         />
-        <div className="fixed inset-0 z-[950] flex items-center justify-center pointer-events-none">
+        <div className="fixed inset-0 z-950 flex items-center justify-center pointer-events-none">
           <div className="pointer-events-auto">
             <TourCard {...cardProps} />
           </div>
@@ -818,7 +829,7 @@ export function TourOverlay() {
       {/* Clickable backdrop to close (passthrough 時は無効化) */}
       <button
         type="button"
-        className="fixed inset-0 z-[900] cursor-default"
+        className="fixed inset-0 z-900 cursor-default"
         onClick={isPassthrough ? undefined : closeOnborda}
         style={{ pointerEvents: isPassthrough ? "none" : "auto" }}
         aria-label="ツアーを閉じる"
@@ -829,7 +840,7 @@ export function TourOverlay() {
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: tour backdrop */}
       <div
         onClick={isPassthrough ? undefined : closeOnborda}
-        className="absolute z-[900] transition-all duration-500 ease-out"
+        className="absolute z-900 transition-all duration-500 ease-out"
         style={{
           left: `${pos.x - padOffset}px`,
           top: `${pos.y - padOffset}px`,
@@ -847,7 +858,7 @@ export function TourOverlay() {
       <div
         ref={cardRef}
         onClick={(e) => e.stopPropagation()}
-        className="absolute z-[950] flex flex-col pointer-events-auto transition-[left,top] duration-500 ease-out"
+        className="absolute z-950 flex flex-col pointer-events-auto transition-[left,top] duration-500 ease-out"
         style={{
           left: `${placement.left}px`,
           top: `${placement.top}px`,

--- a/src/components/ui/GlobalToast.tsx
+++ b/src/components/ui/GlobalToast.tsx
@@ -52,7 +52,10 @@ export function GlobalToast() {
   if (items.length === 0) return null;
 
   return (
-    <div className="pointer-events-none fixed right-4 bottom-4 z-[90] flex max-w-sm flex-col gap-2">
+    <div
+      className="pointer-events-none fixed right-4 z-90 flex max-w-sm flex-col gap-2"
+      style={{ bottom: "calc(env(safe-area-inset-bottom) + 5rem)" }}
+    >
       {items.map((item) => (
         <div
           key={item.id}


### PR DESCRIPTION
## 変更点

- トーストの位置をフローティングボタンの上になるように修正
  - ツアー中などに特にボタンに被って次の操作がしづらい問題の解消
- 重複確認ダイアログをスマホで見たときに画面よりも大きい大きさになって操作できなかった問題を修正
  - 10分セッションがある時間帯で重複ダイアログが出るとはみ出ていた
- 重複確認ダイアログで上下のタイトルとボタンを固定で表示するように
- ダイアログ表示中のスクロール操作が背後のコンテンツに影響しないように
- スマホでのフローティングボタンの位置をアドレスバーが隠れても下に張り付くように
  - Safari で見たときに不自然だったため