### PR TITLE
feat: タイムテーブル/トーク詳細でX投稿導線を改修

### DIFF
--- a/src/app/talks/[id]/OstContent.tsx
+++ b/src/app/talks/[id]/OstContent.tsx
@@ -1,5 +1,6 @@
 import { CopyableTitle } from "@/components/talks/CopyableTitle";
 import { OgpImage } from "@/components/talks/FallbackImage";
+import { TrackHashtagActions } from "@/components/talks/TrackHashtagActions";
 import { TALK_TYPE } from "@/constants/timetable";
 import type { SessionDetail } from "@/utils/getSession";
 import { myTimetable } from "@/utils/myTimetable";
@@ -49,6 +50,15 @@ export function OstContent({
             <div className="text-lg font-bold">
               {detail.day} / {timeRange}（{name}）
             </div>
+            <TrackHashtagActions
+              track={{
+                id: detail.id,
+                name: detail.name,
+                hashtag: detail.hashtag,
+              }}
+              variant="compact"
+              className="mt-2"
+            />
           </section>
 
           <section className="flex flex-col gap-2">

--- a/src/app/talks/[id]/TalkContent.tsx
+++ b/src/app/talks/[id]/TalkContent.tsx
@@ -10,6 +10,7 @@ import {
   TalkStatus,
   ToggleParticipatedButton,
 } from "@/components/talks/TalkStatus";
+import { TrackHashtagActions } from "@/components/talks/TrackHashtagActions";
 import { TALK_TYPE } from "@/constants/timetable";
 import type { SessionDetail } from "@/utils/getSession";
 import { myTimetable } from "@/utils/myTimetable";
@@ -103,6 +104,15 @@ export function TalkContent({
           <div className="text-lg font-bold">
             {detail.day} / {timeRange} （{name}）
           </div>
+          <TrackHashtagActions
+            track={{
+              id: detail.id,
+              name: detail.name,
+              hashtag: detail.hashtag,
+            }}
+            variant="compact"
+            className="mt-2"
+          />
         </div>
 
         <div className="px-6 md:px-8 lg:px-10 flex flex-col md:text-lg [&>*+*]:mt-6 [&>h1+*]:mt-1 [&>h2+*]:mt-1 [&>h3+*]:mt-1">

--- a/src/components/talks/DayTimeTable/SlotTrackHeader.tsx
+++ b/src/components/talks/DayTimeTable/SlotTrackHeader.tsx
@@ -1,42 +1,17 @@
 "use client";
 
-import { Copy } from "lucide-react";
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
 import { TRACK_STYLE } from "@/constants/timetable";
 import type { Track } from "@/types/timetable-api";
+import { TrackHashtagActions } from "../TrackHashtagActions";
 
 export function SlotTrackHeader({ track }: { track: Track }) {
-  const [copySuccess, setCopySuccess] = useState(false);
   const style = TRACK_STYLE[track.id];
-
-  const copyToClipboard = async (text: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopySuccess(true);
-      setTimeout(() => setCopySuccess(false), 2000);
-    } catch (err) {
-      console.error("クリップボードへのコピーに失敗しました", err);
-    }
-  };
 
   return (
     <div className={`${style.bg} p-2 text-center`}>
       <span className={`font-bold ${style.text}`}>{track.name}</span>
-      <div className="flex justify-center mt-2">
-        <Button
-          onClick={() => copyToClipboard(track.hashtag)}
-          className="rounded-full bg-white text-black hover:bg-gray-100 px-4 py-1 text-sm font-medium h-auto flex items-center gap-2"
-        >
-          {copySuccess ? (
-            <span>コピーしました！</span>
-          ) : (
-            <>
-              <span>{track.hashtag}</span>
-              <Copy className="h-4 w-4" />
-            </>
-          )}
-        </Button>
+      <div className="mt-2">
+        <TrackHashtagActions track={track} variant="header" />
       </div>
     </div>
   );

--- a/src/components/talks/DayTimeTable/index.tsx
+++ b/src/components/talks/DayTimeTable/index.tsx
@@ -169,6 +169,11 @@ export function DayTimeTable({
 
       {/* Mobile: vertical stack per timeSlot */}
       <div className="md:hidden">
+        <div className="flex flex-col gap-2 mt-4">
+          {Object.values(data.trackRecord).map((track) => (
+            <SlotTrackHeader key={`m-header-${track.id}`} track={track} />
+          ))}
+        </div>
         {timeSlots.map((slot) => {
           const timeId = myTimetable.formatTime(slot.startTime);
           const timeText = myTimetable.formatTimeRange(

--- a/src/components/talks/TalkDetailDrawer/index.tsx
+++ b/src/components/talks/TalkDetailDrawer/index.tsx
@@ -14,6 +14,7 @@ import {
   TalkStatus,
   ToggleParticipatedButton,
 } from "@/components/talks/TalkStatus";
+import { TrackHashtagActions } from "@/components/talks/TrackHashtagActions";
 import { Button } from "@/components/ui/button";
 import { showAppToast } from "@/components/ui/GlobalToast";
 import { TALK_TYPE, TRACK, TRACK_STYLE } from "@/constants/timetable";
@@ -234,6 +235,11 @@ function DrawerContent({ talk }: { talk: TalkWithMinutes }) {
             {talk.eventDate} / {talk.time} / {TRACK[talk.track].name}
           </span>
         </div>
+        <TrackHashtagActions
+          track={TRACK[talk.track]}
+          variant="compact"
+          className="mt-3"
+        />
       </div>
 
       {talk.overview && (

--- a/src/components/talks/TrackHashtagActions/index.tsx
+++ b/src/components/talks/TrackHashtagActions/index.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { Copy } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { showAppToast } from "@/components/ui/GlobalToast";
+import { cn } from "@/lib/utils";
+import type { Track } from "@/types/timetable-api";
+import { buildXTrackIntentUrl } from "@/utils/xIntent";
+
+type Props = {
+  track: Track;
+  /**
+   * - "header": スロットヘッダー用の大きめボタン（コピーのみ）
+   * - "compact": トーク詳細用の小さめボタン（コピー＋X投稿）
+   */
+  variant?: "header" | "compact";
+  className?: string;
+};
+
+export function TrackHashtagActions({
+  track,
+  variant = "header",
+  className,
+}: Props) {
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(track.hashtag);
+      showAppToast(`${track.hashtag} をコピーしました`);
+    } catch (err) {
+      console.error("クリップボードへのコピーに失敗しました", err);
+    }
+  };
+
+  if (variant === "compact") {
+    const xIntentUrl = buildXTrackIntentUrl(track.hashtag);
+    return (
+      <div className={cn("flex items-center gap-2 flex-wrap", className)}>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="inline-flex items-center gap-1.5 rounded-full bg-white border border-black-400 px-2.5 py-1 text-xs font-medium text-black-700 hover:bg-black-50 active:bg-black-100 cursor-pointer transition-colors"
+        >
+          <span>{track.hashtag}</span>
+          <Copy size={12} className="shrink-0 text-black-400" />
+        </button>
+        <Link
+          href={xIntentUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 rounded-full bg-white border border-black-400 px-2.5 py-1 text-xs font-medium text-black-700 hover:bg-black-50 active:bg-black-100 transition-colors"
+        >
+          <img src="/talks/sns/x-logo.png" alt="X" width={12} height={12} />
+          <span>に投稿</span>
+        </Link>
+      </div>
+    );
+  }
+
+  // header: コピーのみ（タイムテーブル側）
+  return (
+    <div
+      className={cn(
+        "flex justify-center items-center gap-2 flex-wrap",
+        className,
+      )}
+    >
+      <Button
+        type="button"
+        onClick={handleCopy}
+        className="rounded-full bg-white text-black hover:bg-gray-100 px-4 py-1 text-sm font-medium h-auto flex items-center gap-2 cursor-pointer"
+      >
+        <span>{track.hashtag}</span>
+        <Copy className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/src/utils/getSession.ts
+++ b/src/utils/getSession.ts
@@ -10,7 +10,7 @@ import type {
 } from "@/types/timetable-api";
 
 export type SessionDetail = TimeSlot &
-  Pick<Track, "id" | "name"> &
+  Pick<Track, "id" | "name" | "hashtag"> &
   Pick<TimetableResponse, "day" | "date"> & {
     session: SessionSummary;
     sessionType: SessionKey;
@@ -37,7 +37,7 @@ export function getSession(sessionId: SessionId): SessionDetail {
         if (ref.id !== sessionId) continue;
         // Cell may span multiple tracks; pick the first as the canonical track.
         const id = trackKeys[0];
-        const { name } = trackRecord[id];
+        const { name, hashtag } = trackRecord[id];
         const session = resolveSession(sessionId);
         return {
           day,
@@ -47,6 +47,7 @@ export function getSession(sessionId: SessionId): SessionDetail {
           sessionType,
           id,
           name,
+          hashtag,
           session,
         };
       }

--- a/src/utils/xIntent.ts
+++ b/src/utils/xIntent.ts
@@ -1,0 +1,14 @@
+/**
+ * X投稿用の hashtags クエリは "#" 抜きのカンマ区切り。
+ * 例: hashtags=TSKaigi,TSKaigi2026,tskaigi_leverages
+ */
+function buildHashtagsParam(trackHashtag: string): string {
+  const trackTag = trackHashtag.replace(/^#/, "");
+  return ["TSKaigi", "TSKaigi2026", trackTag].join(",");
+}
+
+/** トラックのハッシュタグのみで X 投稿画面を開く URL を生成する */
+export function buildXTrackIntentUrl(trackHashtag: string): string {
+  const hashtags = buildHashtagsParam(trackHashtag);
+  return `https://x.com/intent/post?hashtags=${encodeURIComponent(hashtags)}`;
+}


### PR DESCRIPTION
## Summary
- モバイルタイムテーブルの先頭にトラックヘッダーを縦並びで追加し、ハッシュタグコピーをモバイルでも可能に (Must)
- トーク詳細ページ / トーク詳細ドロワーにもハッシュタグコピー導線を追加 (Must)
- トーク詳細では「Xに投稿」ボタンも追加し、`#TSKaigi` `#TSKaigi2026` `#${トラックタグ}` 入りで X 投稿画面を開けるように (Want)
- 共通コンポーネント `TrackHashtagActions` と X intent URL 生成ユーティリティ `utils/xIntent.ts` を切り出し

## 主な変更点
| 場所 | 変更 |
| --- | --- |
| タイムテーブル (PC) | 既存の `SlotTrackHeader` を共通コンポーネント経由に置き換え (挙動維持) |
| タイムテーブル (モバイル) | 先頭に3トラック分のヘッダー (ハッシュタグコピー) を縦並びで表示 |
| トーク詳細ページ (`TalkContent` / `OstContent`) | 日時・トラック名の下にコンパクト版のコピー+X投稿ボタンを配置 |
| トーク詳細ドロワー (`TalkDetailDrawer`) | トラック名行の下に同じコンパクト版を配置 |
| `SessionDetail` | `hashtag` フィールドを追加 |

## Test plan
- [ ] PC タイムテーブルでこれまで通り各トラックの `#tskaigi_xxx` をコピーできる (トースト表示)
- [ ] モバイル幅 (md未満) でタイムテーブル先頭に3トラック分のコピーボタンが縦並びで表示される
- [ ] トーク詳細ページ (`/talks/[id]`) の日時行の下にコピーボタン + Xに投稿ボタンが表示される
- [ ] Xに投稿ボタンから X の投稿画面が開き、`#TSKaigi #TSKaigi2026 #tskaigi_xxx` がプリセットされている
- [ ] トーク詳細ドロワーでも同じく表示される
- [ ] OST 詳細ページ (`/talks/87`) でも同じく表示される