### PR TITLE
fix: X投稿ボタンをアプリ優先で開き、本文に改行入りハッシュタグを埋め込む

### DIFF
--- a/src/components/talks/TrackHashtagActions/index.tsx
+++ b/src/components/talks/TrackHashtagActions/index.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { Copy } from "lucide-react";
-import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { showAppToast } from "@/components/ui/GlobalToast";
 import { cn } from "@/lib/utils";
 import type { Track } from "@/types/timetable-api";
-import { buildXTrackIntentUrl } from "@/utils/xIntent";
+import {
+  buildXTrackDeepLinkUrl,
+  buildXTrackIntentUrl,
+  openXPostIntent,
+} from "@/utils/xIntent";
 
 type Props = {
   track: Track;
@@ -32,8 +35,14 @@ export function TrackHashtagActions({
     }
   };
 
+  const handleOpenX = () => {
+    openXPostIntent({
+      deepLink: buildXTrackDeepLinkUrl(track.hashtag),
+      webFallback: buildXTrackIntentUrl(track.hashtag),
+    });
+  };
+
   if (variant === "compact") {
-    const xIntentUrl = buildXTrackIntentUrl(track.hashtag);
     return (
       <div className={cn("flex items-center gap-2 flex-wrap", className)}>
         <button
@@ -44,15 +53,14 @@ export function TrackHashtagActions({
           <span>{track.hashtag}</span>
           <Copy size={12} className="shrink-0 text-black-400" />
         </button>
-        <Link
-          href={xIntentUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 rounded-full bg-white border border-black-400 px-2.5 py-1 text-xs font-medium text-black-700 hover:bg-black-50 active:bg-black-100 transition-colors"
+        <button
+          type="button"
+          onClick={handleOpenX}
+          className="inline-flex items-center gap-1.5 rounded-full bg-white border border-black-400 px-2.5 py-1 text-xs font-medium text-black-700 hover:bg-black-50 active:bg-black-100 cursor-pointer transition-colors"
         >
           <img src="/talks/sns/x-logo.png" alt="X" width={12} height={12} />
           <span>に投稿</span>
-        </Link>
+        </button>
       </div>
     );
   }

--- a/src/utils/xIntent.ts
+++ b/src/utils/xIntent.ts
@@ -1,14 +1,72 @@
 /**
- * X投稿用の hashtags クエリは "#" 抜きのカンマ区切り。
- * 例: hashtags=TSKaigi,TSKaigi2026,tskaigi_leverages
+ * X 投稿画面の本文として埋め込むテキスト。
+ * 先頭に空行を入れて、ハッシュタグの上にユーザーがコメントを書き足せる余白を作る。
  */
-function buildHashtagsParam(trackHashtag: string): string {
+function buildPostMessage(trackHashtag: string): string {
   const trackTag = trackHashtag.replace(/^#/, "");
-  return ["TSKaigi", "TSKaigi2026", trackTag].join(",");
+  const hashtags = ["#TSKaigi", "#TSKaigi2026", `#${trackTag}`].join(" ");
+  // "\n\n" で1行分の空行を作り、その下にハッシュタグを並べる
+  return `\n\n${hashtags}`;
 }
 
-/** トラックのハッシュタグのみで X 投稿画面を開く URL を生成する */
+/** トラックのハッシュタグ入りで X 投稿画面を開く Web URL を生成する */
 export function buildXTrackIntentUrl(trackHashtag: string): string {
-  const hashtags = buildHashtagsParam(trackHashtag);
-  return `https://x.com/intent/post?hashtags=${encodeURIComponent(hashtags)}`;
+  const text = buildPostMessage(trackHashtag);
+  return `https://x.com/intent/post?text=${encodeURIComponent(text)}`;
+}
+
+/**
+ * X アプリ用の deep link を生成する。
+ * `twitter://post?message=...` は iOS/Android の X アプリで投稿画面を開く。
+ */
+export function buildXTrackDeepLinkUrl(trackHashtag: string): string {
+  const message = buildPostMessage(trackHashtag);
+  return `twitter://post?message=${encodeURIComponent(message)}`;
+}
+
+const MOBILE_UA_REGEX = /iPhone|iPad|iPod|Android/i;
+
+function isMobileDevice(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return MOBILE_UA_REGEX.test(navigator.userAgent);
+}
+
+/**
+ * X の投稿画面を開く。
+ * - モバイル: `twitter://` deep link を試し、開けなければ Web Intent にフォールバック
+ * - PC: Web Intent を新しいタブで開く
+ *
+ * deep link で X アプリが起動した場合、ページが非表示になることを `visibilitychange` で検知して
+ * フォールバックを抑止する。一定時間内にページが非表示にならなければアプリ未インストールと判断する。
+ */
+export function openXPostIntent({
+  deepLink,
+  webFallback,
+}: {
+  deepLink: string;
+  webFallback: string;
+}): void {
+  if (!isMobileDevice()) {
+    window.open(webFallback, "_blank", "noopener,noreferrer");
+    return;
+  }
+
+  let appOpened = false;
+  const onVisibilityChange = () => {
+    if (document.hidden) {
+      appOpened = true;
+    }
+  };
+  document.addEventListener("visibilitychange", onVisibilityChange);
+
+  // deep link を発火
+  window.location.href = deepLink;
+
+  // 一定時間内に visibility が hidden にならなければ Web Intent にフォールバック
+  window.setTimeout(() => {
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+    if (!appOpened && !document.hidden) {
+      window.location.href = webFallback;
+    }
+  }, 1200);
 }


### PR DESCRIPTION
- モバイルでは twitter:// deep link を試し、visibilitychange で X アプリ起動を検知。 起動しなければ Web Intent にフォールバック
- PC は従来通り Web Intent を新タブで開く
- ハッシュタグの上に空行を入れて、ユーザーがコメントを書ける余白を確保 （hashtags パラメータ → text パラメータに改行入りで埋め込む形に変更）