### PR TITLE
feat: セッションの持ち時間をカウントダウンするタイムキーパーページを追加する

### DIFF
--- a/src/app/timekeep/_components/CustomTimeForm.tsx
+++ b/src/app/timekeep/_components/CustomTimeForm.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/ui/input";
+
+type Props = {
+  /** 持ち時間（分。秒は小数で含む）を確定する。 */
+  onApply: (minutes: number) => void;
+};
+
+const PRESET_MINUTES = [3, 5, 10, 15, 30];
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function CustomTimeForm({ onApply }: Props) {
+  const [minutes, setMinutes] = useState("10");
+  const [seconds, setSeconds] = useState("0");
+
+  const parsedMinutes = clamp(Number.parseInt(minutes, 10) || 0, 0, 999);
+  const parsedSeconds = clamp(Number.parseInt(seconds, 10) || 0, 0, 59);
+  const totalMinutes = parsedMinutes + parsedSeconds / 60;
+
+  const handleApply = () => {
+    if (totalMinutes <= 0) return;
+    onApply(totalMinutes);
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h3 className="text-sm font-bold text-blue-light-600">
+        時間を自由に設定
+      </h3>
+
+      <div className="flex flex-wrap gap-2">
+        {PRESET_MINUTES.map((preset) => (
+          <button
+            key={preset}
+            type="button"
+            onClick={() => onApply(preset)}
+            className="rounded-full border border-blue-light-300 bg-white px-3 py-1 text-sm font-medium text-blue-light-600 transition-colors hover:border-blue-light-400"
+          >
+            {preset}分
+          </button>
+        ))}
+      </div>
+
+      <div className="flex items-end gap-2">
+        <div className="flex flex-1 flex-col gap-1 text-xs text-black-500">
+          <label htmlFor="timekeep-custom-minutes">分</label>
+          <Input
+            id="timekeep-custom-minutes"
+            type="number"
+            inputMode="numeric"
+            min={0}
+            max={999}
+            value={minutes}
+            onChange={(e) => setMinutes(e.target.value)}
+          />
+        </div>
+        <div className="flex flex-1 flex-col gap-1 text-xs text-black-500">
+          <label htmlFor="timekeep-custom-seconds">秒</label>
+          <Input
+            id="timekeep-custom-seconds"
+            type="number"
+            inputMode="numeric"
+            min={0}
+            max={59}
+            value={seconds}
+            onChange={(e) => setSeconds(e.target.value)}
+          />
+        </div>
+        <Button
+          type="button"
+          onClick={handleApply}
+          disabled={totalMinutes <= 0}
+        >
+          セット
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/timekeep/_components/SessionPicker.tsx
+++ b/src/app/timekeep/_components/SessionPicker.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { TALK_TYPE, TRACK_KEYS } from "@/constants/timetable";
+import { cn } from "@/lib/utils";
+import type { EventDate } from "@/types/timetable-api";
+import type { TimekeepSession } from "@/utils/getTimekeepSessions";
+
+type Props = {
+  sessions: TimekeepSession[];
+  selectedId: string | null;
+  onSelect: (session: TimekeepSession) => void;
+};
+
+const DAYS: { value: EventDate; label: string }[] = [
+  { value: "Day1", label: "Day1 (5/22)" },
+  { value: "Day2", label: "Day2 (5/23)" },
+];
+
+export function SessionPicker({ sessions, selectedId, onSelect }: Props) {
+  const [activeDay, setActiveDay] = useState<EventDate>("Day1");
+
+  const daySessions = sessions.filter((s) => s.day === activeDay);
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex gap-2">
+        {DAYS.map((day) => (
+          <button
+            key={day.value}
+            type="button"
+            onClick={() => setActiveDay(day.value)}
+            className={cn(
+              "rounded-full px-4 py-1.5 text-sm font-medium transition-colors",
+              activeDay === day.value
+                ? "bg-blue-light-500 text-white"
+                : "bg-white text-blue-light-600 border border-blue-light-300",
+            )}
+          >
+            {day.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex flex-col gap-6">
+        {TRACK_KEYS.map((track) => {
+          const trackSessions = daySessions.filter((s) => s.track === track);
+          if (trackSessions.length === 0) return null;
+          const trackName = trackSessions[0].trackName;
+
+          return (
+            <div key={track} className="flex flex-col gap-2">
+              <h3 className="text-sm font-bold text-blue-light-600">
+                {trackName}
+              </h3>
+              <ul className="flex flex-col gap-2">
+                {trackSessions.map((session) => {
+                  const isSelected = session.id === selectedId;
+                  const typeLabel = TALK_TYPE[session.sessionType].name;
+                  return (
+                    <li key={`${session.track}-${session.id}`}>
+                      <button
+                        type="button"
+                        onClick={() => onSelect(session)}
+                        aria-pressed={isSelected}
+                        className={cn(
+                          "w-full rounded-xl border bg-white p-3 text-left transition-colors",
+                          isSelected
+                            ? "border-blue-light-500 ring-2 ring-blue-light-300"
+                            : "border-black-300 hover:border-blue-light-400",
+                        )}
+                      >
+                        <div className="flex items-center gap-2 text-xs text-black-400">
+                          <span className="tabular-nums">
+                            {session.cellTime}
+                          </span>
+                          <span
+                            className="rounded-full px-2 py-0.5 font-medium text-white"
+                            style={{
+                              backgroundColor:
+                                TALK_TYPE[session.sessionType].color,
+                            }}
+                          >
+                            {typeLabel}
+                          </span>
+                          <span className="ml-auto font-semibold text-blue-light-600">
+                            {session.durationMinutes}分
+                          </span>
+                        </div>
+                        <p className="mt-1 line-clamp-2 text-sm font-medium text-black-600">
+                          {session.title}
+                        </p>
+                        {session.speaker && (
+                          <p className="mt-0.5 text-xs text-black-400">
+                            {session.speaker}
+                          </p>
+                        )}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/app/timekeep/_components/TimerDisplay.tsx
+++ b/src/app/timekeep/_components/TimerDisplay.tsx
@@ -1,0 +1,96 @@
+import { cn } from "@/lib/utils";
+import type { TimekeepPhase } from "../useTimekeepTimer";
+
+type Props = {
+  phase: TimekeepPhase;
+  remainingSeconds: number;
+  phaseTotalSeconds: number;
+};
+
+function formatClock(totalSeconds: number): string {
+  const safe = Math.max(0, totalSeconds);
+  const minutes = Math.floor(safe / 60);
+  const seconds = safe % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+const SESSION_WARNING_THRESHOLD_SECONDS = 60;
+
+function getAppearance(phase: TimekeepPhase, remainingSeconds: number) {
+  if (phase === "ended") {
+    return {
+      label: "強制終了",
+      container: "bg-red-700 text-white",
+      bar: "bg-white/70",
+      pulse: false,
+    };
+  }
+  if (phase === "forced") {
+    return {
+      label: "強制終了まで",
+      container: "bg-red-600 text-white",
+      bar: "bg-white/80",
+      pulse: true,
+    };
+  }
+  if (remainingSeconds <= SESSION_WARNING_THRESHOLD_SECONDS) {
+    return {
+      label: "まもなく終了",
+      container: "bg-orange-500 text-white",
+      bar: "bg-white/80",
+      pulse: false,
+    };
+  }
+  return {
+    label: "セッション終了まで",
+    container: "bg-blue-light-500 text-white",
+    bar: "bg-white/80",
+    pulse: false,
+  };
+}
+
+export function TimerDisplay({
+  phase,
+  remainingSeconds,
+  phaseTotalSeconds,
+}: Props) {
+  const { label, container, bar, pulse } = getAppearance(
+    phase,
+    remainingSeconds,
+  );
+  const progress =
+    phaseTotalSeconds > 0
+      ? Math.min(100, Math.max(0, (remainingSeconds / phaseTotalSeconds) * 100))
+      : 0;
+
+  return (
+    <div
+      className={cn(
+        "relative w-full overflow-hidden rounded-2xl px-6 py-10 shadow-[0_4px_6px_rgba(0,0,0,0.09)] transition-colors duration-300 md:py-14",
+        container,
+      )}
+    >
+      <p className="text-center text-base font-medium tracking-wide md:text-xl">
+        {label}
+      </p>
+      <p
+        className={cn(
+          "mt-2 text-center font-semibold tabular-nums leading-none text-7xl md:text-9xl",
+          pulse && "motion-safe:animate-pulse",
+        )}
+      >
+        {phase === "ended" ? "0:00" : formatClock(remainingSeconds)}
+      </p>
+
+      <div className="mt-8 h-2 w-full overflow-hidden rounded-full bg-black/15">
+        <div
+          className={cn(
+            "h-full rounded-full transition-[width] duration-300",
+            bar,
+          )}
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/timekeep/_components/TimerDisplay.tsx
+++ b/src/app/timekeep/_components/TimerDisplay.tsx
@@ -5,6 +5,7 @@ type Props = {
   phase: TimekeepPhase;
   remainingSeconds: number;
   phaseTotalSeconds: number;
+  isFullscreen?: boolean;
 };
 
 function formatClock(totalSeconds: number): string {
@@ -53,6 +54,7 @@ export function TimerDisplay({
   phase,
   remainingSeconds,
   phaseTotalSeconds,
+  isFullscreen = false,
 }: Props) {
   const { label, container, bar, pulse } = getAppearance(
     phase,
@@ -66,23 +68,37 @@ export function TimerDisplay({
   return (
     <div
       className={cn(
-        "relative w-full overflow-hidden rounded-2xl px-6 py-10 shadow-[0_4px_6px_rgba(0,0,0,0.09)] transition-colors duration-300 md:py-14",
+        "relative w-full overflow-hidden rounded-2xl shadow-[0_4px_6px_rgba(0,0,0,0.09)] transition-colors duration-300",
+        isFullscreen ? "px-8 py-12" : "px-6 py-10 md:py-14",
         container,
       )}
     >
-      <p className="text-center text-base font-medium tracking-wide md:text-xl">
+      <p
+        className={cn(
+          "text-center font-medium tracking-wide",
+          isFullscreen ? "text-2xl md:text-4xl" : "text-base md:text-xl",
+        )}
+      >
         {label}
       </p>
       <p
         className={cn(
-          "mt-2 text-center font-semibold tabular-nums leading-none text-7xl md:text-9xl",
+          "mt-2 text-center font-semibold tabular-nums leading-none",
+          isFullscreen
+            ? "text-[22vw] md:text-[18vw]"
+            : "text-8xl md:text-[9rem] lg:text-[11rem]",
           pulse && "motion-safe:animate-pulse",
         )}
       >
         {phase === "ended" ? "0:00" : formatClock(remainingSeconds)}
       </p>
 
-      <div className="mt-8 h-2 w-full overflow-hidden rounded-full bg-black/15">
+      <div
+        className={cn(
+          "w-full overflow-hidden rounded-full bg-black/15",
+          isFullscreen ? "mt-12 h-3" : "mt-8 h-2",
+        )}
+      >
         <div
           className={cn(
             "h-full rounded-full transition-[width] duration-300",

--- a/src/app/timekeep/layout.tsx
+++ b/src/app/timekeep/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "タイムキーパー",
+  robots: "noindex, nofollow",
+};
+
+export default function TimekeepLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/timekeep/page.tsx
+++ b/src/app/timekeep/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { TALK_TYPE } from "@/constants/timetable";
+import {
+  getTimekeepSessions,
+  type TimekeepSession,
+} from "@/utils/getTimekeepSessions";
+import { SessionPicker } from "./_components/SessionPicker";
+import { TimerDisplay } from "./_components/TimerDisplay";
+import {
+  FORCED_TERMINATION_MINUTES,
+  useTimekeepTimer,
+} from "./useTimekeepTimer";
+
+export default function TimekeepPage() {
+  const sessions = useMemo(() => getTimekeepSessions(), []);
+  const [selected, setSelected] = useState<TimekeepSession | null>(null);
+
+  const timer = useTimekeepTimer(selected?.durationMinutes ?? 0, selected?.id);
+
+  const startLabel = timer.isRunning
+    ? "一時停止"
+    : timer.phase === "session" &&
+        timer.remainingSeconds === (selected?.durationMinutes ?? 0) * 60
+      ? "スタート"
+      : "再開";
+
+  return (
+    <main className="bg-blue-light-100 flex-1 px-4 pt-20 pb-16">
+      <div className="mx-auto flex max-w-2xl flex-col gap-6">
+        <header className="flex flex-col gap-2 text-center">
+          <h1 className="text-2xl font-bold text-blue-light-500 md:text-3xl">
+            タイムキーパー
+          </h1>
+          <p className="text-sm text-black-500">
+            セッションを選ぶと持ち時間をカウントダウンします。0になると一律で
+            「強制終了まで{FORCED_TERMINATION_MINUTES}分」のカウントダウンに
+            切り替わります。
+          </p>
+        </header>
+
+        {selected ? (
+          <div className="rounded-xl border border-blue-light-300 bg-white p-4">
+            <div className="flex items-center gap-2 text-xs text-black-400">
+              <span
+                className="rounded-full px-2 py-0.5 font-medium text-white"
+                style={{
+                  backgroundColor: TALK_TYPE[selected.sessionType].color,
+                }}
+              >
+                {TALK_TYPE[selected.sessionType].name}
+              </span>
+              <span className="tabular-nums">{selected.cellTime}</span>
+              <span className="ml-auto font-semibold text-blue-light-600">
+                持ち時間 {selected.durationMinutes}分
+              </span>
+            </div>
+            <p className="mt-2 text-base font-bold text-black-600">
+              {selected.title}
+            </p>
+            <p className="mt-0.5 text-sm text-black-400">
+              {selected.trackName}
+              {selected.speaker && ` ・ ${selected.speaker}`}
+            </p>
+          </div>
+        ) : (
+          <p className="rounded-xl border border-dashed border-blue-light-300 bg-white p-6 text-center text-sm text-black-400">
+            下のリストからセッションを選択してください。
+          </p>
+        )}
+
+        {selected && (
+          <>
+            <TimerDisplay
+              phase={timer.phase}
+              remainingSeconds={timer.remainingSeconds}
+              phaseTotalSeconds={timer.phaseTotalSeconds}
+            />
+            <div className="flex gap-3">
+              <Button
+                type="button"
+                size="lg"
+                className="flex-1"
+                disabled={timer.phase === "ended"}
+                onClick={timer.isRunning ? timer.pause : timer.start}
+              >
+                {startLabel}
+              </Button>
+              <Button
+                type="button"
+                size="lg"
+                variant="outline"
+                className="flex-1"
+                onClick={timer.reset}
+              >
+                リセット
+              </Button>
+            </div>
+          </>
+        )}
+
+        <SessionPicker
+          sessions={sessions}
+          selectedId={selected?.id ?? null}
+          onSelect={setSelected}
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/app/timekeep/page.tsx
+++ b/src/app/timekeep/page.tsx
@@ -1,8 +1,18 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { Maximize, Minimize } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
 import { TALK_TYPE } from "@/constants/timetable";
+import { cn } from "@/lib/utils";
 import {
   getTimekeepSessions,
   type TimekeepSession,
@@ -17,8 +27,33 @@ import {
 export default function TimekeepPage() {
   const sessions = useMemo(() => getTimekeepSessions(), []);
   const [selected, setSelected] = useState<TimekeepSession | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   const timer = useTimekeepTimer(selected?.durationMinutes ?? 0, selected?.id);
+
+  const fullscreenRef = useRef<HTMLDivElement>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [fullscreenSupported, setFullscreenSupported] = useState(false);
+
+  useEffect(() => {
+    setFullscreenSupported(document.fullscreenEnabled);
+    const onChange = () => setIsFullscreen(Boolean(document.fullscreenElement));
+    document.addEventListener("fullscreenchange", onChange);
+    return () => document.removeEventListener("fullscreenchange", onChange);
+  }, []);
+
+  const toggleFullscreen = useCallback(() => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+    } else {
+      fullscreenRef.current?.requestFullscreen();
+    }
+  }, []);
+
+  const handleSelect = useCallback((session: TimekeepSession) => {
+    setSelected(session);
+    setPickerOpen(false);
+  }, []);
 
   const startLabel = timer.isRunning
     ? "一時停止"
@@ -41,43 +76,70 @@ export default function TimekeepPage() {
           </p>
         </header>
 
-        {selected ? (
-          <div className="rounded-xl border border-blue-light-300 bg-white p-4">
-            <div className="flex items-center gap-2 text-xs text-black-400">
-              <span
-                className="rounded-full px-2 py-0.5 font-medium text-white"
-                style={{
-                  backgroundColor: TALK_TYPE[selected.sessionType].color,
-                }}
-              >
-                {TALK_TYPE[selected.sessionType].name}
-              </span>
-              <span className="tabular-nums">{selected.cellTime}</span>
-              <span className="ml-auto font-semibold text-blue-light-600">
-                持ち時間 {selected.durationMinutes}分
-              </span>
-            </div>
-            <p className="mt-2 text-base font-bold text-black-600">
-              {selected.title}
-            </p>
-            <p className="mt-0.5 text-sm text-black-400">
-              {selected.trackName}
-              {selected.speaker && ` ・ ${selected.speaker}`}
-            </p>
-          </div>
-        ) : (
-          <p className="rounded-xl border border-dashed border-blue-light-300 bg-white p-6 text-center text-sm text-black-400">
-            下のリストからセッションを選択してください。
-          </p>
-        )}
+        <Sheet open={pickerOpen} onOpenChange={setPickerOpen}>
+          <SheetTrigger asChild>
+            <Button type="button" variant="outline" className="w-full">
+              {selected ? "セッションを変更する" : "セッションを選択する"}
+            </Button>
+          </SheetTrigger>
+          <SheetContent
+            side="right"
+            className="flex w-full max-w-md flex-col gap-4 overflow-y-auto sm:max-w-md"
+          >
+            <SheetHeader>
+              <SheetTitle>セッションを選択</SheetTitle>
+              <SheetDescription>
+                選んだセッションの持ち時間が自動で設定されます。
+              </SheetDescription>
+            </SheetHeader>
+            <SessionPicker
+              sessions={sessions}
+              selectedId={selected?.id ?? null}
+              onSelect={handleSelect}
+            />
+          </SheetContent>
+        </Sheet>
 
-        {selected && (
-          <>
+        {selected ? (
+          <div
+            ref={fullscreenRef}
+            className={cn(
+              "flex flex-col gap-6",
+              isFullscreen &&
+                "h-screen w-screen justify-center bg-blue-light-100 px-6",
+            )}
+          >
+            <div className="rounded-xl border border-blue-light-300 bg-white p-4">
+              <div className="flex items-center gap-2 text-xs text-black-400">
+                <span
+                  className="rounded-full px-2 py-0.5 font-medium text-white"
+                  style={{
+                    backgroundColor: TALK_TYPE[selected.sessionType].color,
+                  }}
+                >
+                  {TALK_TYPE[selected.sessionType].name}
+                </span>
+                <span className="tabular-nums">{selected.cellTime}</span>
+                <span className="ml-auto font-semibold text-blue-light-600">
+                  持ち時間 {selected.durationMinutes}分
+                </span>
+              </div>
+              <p className="mt-2 text-base font-bold text-black-600">
+                {selected.title}
+              </p>
+              <p className="mt-0.5 text-sm text-black-400">
+                {selected.trackName}
+                {selected.speaker && ` ・ ${selected.speaker}`}
+              </p>
+            </div>
+
             <TimerDisplay
               phase={timer.phase}
               remainingSeconds={timer.remainingSeconds}
               phaseTotalSeconds={timer.phaseTotalSeconds}
+              isFullscreen={isFullscreen}
             />
+
             <div className="flex gap-3">
               <Button
                 type="button"
@@ -97,15 +159,28 @@ export default function TimekeepPage() {
               >
                 リセット
               </Button>
+              {fullscreenSupported && (
+                <Button
+                  type="button"
+                  size="lg"
+                  variant="outline"
+                  onClick={toggleFullscreen}
+                  aria-label={isFullscreen ? "全画面を終了" : "全画面表示"}
+                >
+                  {isFullscreen ? (
+                    <Minimize className="size-5" />
+                  ) : (
+                    <Maximize className="size-5" />
+                  )}
+                </Button>
+              )}
             </div>
-          </>
+          </div>
+        ) : (
+          <p className="rounded-xl border border-dashed border-blue-light-300 bg-white p-6 text-center text-sm text-black-400">
+            セッションを選択するとタイマーが表示されます。
+          </p>
         )}
-
-        <SessionPicker
-          sessions={sessions}
-          selectedId={selected?.id ?? null}
-          onSelect={setSelected}
-        />
       </div>
     </main>
   );

--- a/src/app/timekeep/page.tsx
+++ b/src/app/timekeep/page.tsx
@@ -52,7 +52,18 @@ export default function TimekeepPage() {
   const resetKey = active === null ? undefined : `${active.kind}-${applyToken}`;
 
   const timer = useTimekeepTimer(durationMinutes, resetKey);
-  const playBell = useBell();
+  const { play: playBell, unlock: unlockBell } = useBell();
+
+  // 0秒到達でベルを鳴らす。セッション終了(→強制終了フェーズ)と強制終了の両方。
+  const prevPhaseRef = useRef(timer.phase);
+  useEffect(() => {
+    if (prevPhaseRef.current !== timer.phase) {
+      if (timer.phase === "forced" || timer.phase === "ended") {
+        playBell();
+      }
+      prevPhaseRef.current = timer.phase;
+    }
+  }, [timer.phase, playBell]);
 
   const fullscreenRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -213,7 +224,14 @@ export default function TimekeepPage() {
                   size="lg"
                   className="flex-1"
                   disabled={timer.phase === "ended"}
-                  onClick={timer.isRunning ? timer.pause : timer.start}
+                  onClick={
+                    timer.isRunning
+                      ? timer.pause
+                      : () => {
+                          unlockBell();
+                          timer.start();
+                        }
+                  }
                 >
                   {startLabel}
                 </Button>

--- a/src/app/timekeep/page.tsx
+++ b/src/app/timekeep/page.tsx
@@ -83,6 +83,14 @@ export default function TimekeepPage() {
     setPickerOpen(false);
   }, []);
 
+  const openPicker = useCallback(() => {
+    // 全画面中はドロワーが見えないため、全画面を解除してから開く。
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+    }
+    setPickerOpen(true);
+  }, []);
+
   const initialSeconds = Math.round(durationMinutes * 60);
   const startLabel = timer.isRunning
     ? "一時停止"
@@ -142,7 +150,12 @@ export default function TimekeepPage() {
             )}
           >
             {active.kind === "session" ? (
-              <div className="rounded-xl border border-blue-light-300 bg-white p-4">
+              <button
+                type="button"
+                onClick={openPicker}
+                aria-label="セッション・時間を変更する"
+                className="w-full cursor-pointer rounded-xl border border-blue-light-300 bg-white p-4 text-left transition-colors hover:border-blue-light-400"
+              >
                 <div className="flex items-center gap-2 text-xs text-black-400">
                   <span
                     className="rounded-full px-2 py-0.5 font-medium text-white"
@@ -167,16 +180,21 @@ export default function TimekeepPage() {
                   {active.session.trackName}
                   {active.session.speaker && ` ・ ${active.session.speaker}`}
                 </p>
-              </div>
+              </button>
             ) : (
-              <div className="flex items-center justify-between rounded-xl border border-blue-light-300 bg-white p-4">
+              <button
+                type="button"
+                onClick={openPicker}
+                aria-label="セッション・時間を変更する"
+                className="flex w-full cursor-pointer items-center justify-between rounded-xl border border-blue-light-300 bg-white p-4 text-left transition-colors hover:border-blue-light-400"
+              >
                 <p className="text-base font-bold text-black-600">
                   カスタムタイマー
                 </p>
                 <span className="font-semibold text-blue-light-600">
                   持ち時間 {formatCustomDuration(active.minutes)}
                 </span>
-              </div>
+              </button>
             )}
 
             <TimerDisplay

--- a/src/app/timekeep/page.tsx
+++ b/src/app/timekeep/page.tsx
@@ -17,6 +17,7 @@ import {
   getTimekeepSessions,
   type TimekeepSession,
 } from "@/utils/getTimekeepSessions";
+import { CustomTimeForm } from "./_components/CustomTimeForm";
 import { SessionPicker } from "./_components/SessionPicker";
 import { TimerDisplay } from "./_components/TimerDisplay";
 import {
@@ -24,12 +25,32 @@ import {
   useTimekeepTimer,
 } from "./useTimekeepTimer";
 
+type ActiveTimer =
+  | { kind: "session"; session: TimekeepSession }
+  | { kind: "custom"; minutes: number };
+
+function formatCustomDuration(totalMinutes: number): string {
+  const totalSeconds = Math.round(totalMinutes * 60);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return seconds === 0 ? `${minutes}分` : `${minutes}分${seconds}秒`;
+}
+
 export default function TimekeepPage() {
   const sessions = useMemo(() => getTimekeepSessions(), []);
-  const [selected, setSelected] = useState<TimekeepSession | null>(null);
+  const [active, setActive] = useState<ActiveTimer | null>(null);
+  const [applyToken, setApplyToken] = useState(0);
   const [pickerOpen, setPickerOpen] = useState(false);
 
-  const timer = useTimekeepTimer(selected?.durationMinutes ?? 0, selected?.id);
+  const durationMinutes =
+    active === null
+      ? 0
+      : active.kind === "session"
+        ? active.session.durationMinutes
+        : active.minutes;
+  const resetKey = active === null ? undefined : `${active.kind}-${applyToken}`;
+
+  const timer = useTimekeepTimer(durationMinutes, resetKey);
 
   const fullscreenRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -50,15 +71,22 @@ export default function TimekeepPage() {
     }
   }, []);
 
-  const handleSelect = useCallback((session: TimekeepSession) => {
-    setSelected(session);
+  const applySession = useCallback((session: TimekeepSession) => {
+    setActive({ kind: "session", session });
+    setApplyToken((t) => t + 1);
     setPickerOpen(false);
   }, []);
 
+  const applyCustom = useCallback((minutes: number) => {
+    setActive({ kind: "custom", minutes });
+    setApplyToken((t) => t + 1);
+    setPickerOpen(false);
+  }, []);
+
+  const initialSeconds = Math.round(durationMinutes * 60);
   const startLabel = timer.isRunning
     ? "一時停止"
-    : timer.phase === "session" &&
-        timer.remainingSeconds === (selected?.durationMinutes ?? 0) * 60
+    : timer.phase === "session" && timer.remainingSeconds === initialSeconds
       ? "スタート"
       : "再開";
 
@@ -70,16 +98,16 @@ export default function TimekeepPage() {
             タイムキーパー
           </h1>
           <p className="text-sm text-black-500">
-            セッションを選ぶと持ち時間をカウントダウンします。0になると一律で
-            「強制終了まで{FORCED_TERMINATION_MINUTES}分」のカウントダウンに
-            切り替わります。
+            {`セッションを選ぶか時間を自由に設定するとカウントダウンします。0になると一律で「強制終了まで${FORCED_TERMINATION_MINUTES}分」のカウントダウンに切り替わります。`}
           </p>
         </header>
 
         <Sheet open={pickerOpen} onOpenChange={setPickerOpen}>
           <SheetTrigger asChild>
             <Button type="button" variant="outline" className="w-full">
-              {selected ? "セッションを変更する" : "セッションを選択する"}
+              {active
+                ? "セッション・時間を変更する"
+                : "セッション・時間を設定する"}
             </Button>
           </SheetTrigger>
           <SheetContent
@@ -87,20 +115,24 @@ export default function TimekeepPage() {
             className="flex w-full max-w-md flex-col gap-4 overflow-y-auto sm:max-w-md"
           >
             <SheetHeader>
-              <SheetTitle>セッションを選択</SheetTitle>
+              <SheetTitle>セッション・時間を設定</SheetTitle>
               <SheetDescription>
-                選んだセッションの持ち時間が自動で設定されます。
+                {
+                  "セッションを選ぶと持ち時間が自動で設定されます。時間を直接指定することもできます。"
+                }
               </SheetDescription>
             </SheetHeader>
+            <CustomTimeForm onApply={applyCustom} />
+            <div className="h-px bg-black-200" />
             <SessionPicker
               sessions={sessions}
-              selectedId={selected?.id ?? null}
-              onSelect={handleSelect}
+              selectedId={active?.kind === "session" ? active.session.id : null}
+              onSelect={applySession}
             />
           </SheetContent>
         </Sheet>
 
-        {selected ? (
+        {active ? (
           <div
             ref={fullscreenRef}
             className={cn(
@@ -109,29 +141,43 @@ export default function TimekeepPage() {
                 "h-screen w-screen justify-center bg-blue-light-100 px-6",
             )}
           >
-            <div className="rounded-xl border border-blue-light-300 bg-white p-4">
-              <div className="flex items-center gap-2 text-xs text-black-400">
-                <span
-                  className="rounded-full px-2 py-0.5 font-medium text-white"
-                  style={{
-                    backgroundColor: TALK_TYPE[selected.sessionType].color,
-                  }}
-                >
-                  {TALK_TYPE[selected.sessionType].name}
-                </span>
-                <span className="tabular-nums">{selected.cellTime}</span>
-                <span className="ml-auto font-semibold text-blue-light-600">
-                  持ち時間 {selected.durationMinutes}分
+            {active.kind === "session" ? (
+              <div className="rounded-xl border border-blue-light-300 bg-white p-4">
+                <div className="flex items-center gap-2 text-xs text-black-400">
+                  <span
+                    className="rounded-full px-2 py-0.5 font-medium text-white"
+                    style={{
+                      backgroundColor:
+                        TALK_TYPE[active.session.sessionType].color,
+                    }}
+                  >
+                    {TALK_TYPE[active.session.sessionType].name}
+                  </span>
+                  <span className="tabular-nums">
+                    {active.session.cellTime}
+                  </span>
+                  <span className="ml-auto font-semibold text-blue-light-600">
+                    持ち時間 {active.session.durationMinutes}分
+                  </span>
+                </div>
+                <p className="mt-2 text-base font-bold text-black-600">
+                  {active.session.title}
+                </p>
+                <p className="mt-0.5 text-sm text-black-400">
+                  {active.session.trackName}
+                  {active.session.speaker && ` ・ ${active.session.speaker}`}
+                </p>
+              </div>
+            ) : (
+              <div className="flex items-center justify-between rounded-xl border border-blue-light-300 bg-white p-4">
+                <p className="text-base font-bold text-black-600">
+                  カスタムタイマー
+                </p>
+                <span className="font-semibold text-blue-light-600">
+                  持ち時間 {formatCustomDuration(active.minutes)}
                 </span>
               </div>
-              <p className="mt-2 text-base font-bold text-black-600">
-                {selected.title}
-              </p>
-              <p className="mt-0.5 text-sm text-black-400">
-                {selected.trackName}
-                {selected.speaker && ` ・ ${selected.speaker}`}
-              </p>
-            </div>
+            )}
 
             <TimerDisplay
               phase={timer.phase}
@@ -178,7 +224,7 @@ export default function TimekeepPage() {
           </div>
         ) : (
           <p className="rounded-xl border border-dashed border-blue-light-300 bg-white p-6 text-center text-sm text-black-400">
-            セッションを選択するとタイマーが表示されます。
+            セッションを選ぶか時間を設定するとタイマーが表示されます。
           </p>
         )}
       </div>

--- a/src/app/timekeep/page.tsx
+++ b/src/app/timekeep/page.tsx
@@ -52,18 +52,25 @@ export default function TimekeepPage() {
   const resetKey = active === null ? undefined : `${active.kind}-${applyToken}`;
 
   const timer = useTimekeepTimer(durationMinutes, resetKey);
-  const { play: playBell, unlock: unlockBell } = useBell();
+  const {
+    play: playBell,
+    playDouble: playBellDouble,
+    unlock: unlockBell,
+  } = useBell();
 
-  // 0秒到達でベルを鳴らす。セッション終了(→強制終了フェーズ)と強制終了の両方。
+  // 0秒到達でベルを鳴らす。セッション終了(→強制終了フェーズ)は1回、
+  // 強制終了は短く2回（チンチン）。
   const prevPhaseRef = useRef(timer.phase);
   useEffect(() => {
     if (prevPhaseRef.current !== timer.phase) {
-      if (timer.phase === "forced" || timer.phase === "ended") {
+      if (timer.phase === "forced") {
         playBell();
+      } else if (timer.phase === "ended") {
+        playBellDouble();
       }
       prevPhaseRef.current = timer.phase;
     }
-  }, [timer.phase, playBell]);
+  }, [timer.phase, playBell, playBellDouble]);
 
   const fullscreenRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);

--- a/src/app/timekeep/page.tsx
+++ b/src/app/timekeep/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Maximize, Minimize } from "lucide-react";
+import { Bell, Maximize, Minimize } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -20,6 +20,7 @@ import {
 import { CustomTimeForm } from "./_components/CustomTimeForm";
 import { SessionPicker } from "./_components/SessionPicker";
 import { TimerDisplay } from "./_components/TimerDisplay";
+import { useBell } from "./useBell";
 import {
   FORCED_TERMINATION_MINUTES,
   useTimekeepTimer,
@@ -51,6 +52,7 @@ export default function TimekeepPage() {
   const resetKey = active === null ? undefined : `${active.kind}-${applyToken}`;
 
   const timer = useTimekeepTimer(durationMinutes, resetKey);
+  const playBell = useBell();
 
   const fullscreenRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -204,40 +206,54 @@ export default function TimekeepPage() {
               isFullscreen={isFullscreen}
             />
 
-            <div className="flex gap-3">
-              <Button
-                type="button"
-                size="lg"
-                className="flex-1"
-                disabled={timer.phase === "ended"}
-                onClick={timer.isRunning ? timer.pause : timer.start}
-              >
-                {startLabel}
-              </Button>
-              <Button
-                type="button"
-                size="lg"
-                variant="outline"
-                className="flex-1"
-                onClick={timer.reset}
-              >
-                リセット
-              </Button>
-              {fullscreenSupported && (
+            <div className="flex flex-col gap-3">
+              <div className="flex gap-3">
+                <Button
+                  type="button"
+                  size="lg"
+                  className="flex-1"
+                  disabled={timer.phase === "ended"}
+                  onClick={timer.isRunning ? timer.pause : timer.start}
+                >
+                  {startLabel}
+                </Button>
                 <Button
                   type="button"
                   size="lg"
                   variant="outline"
-                  onClick={toggleFullscreen}
-                  aria-label={isFullscreen ? "全画面を終了" : "全画面表示"}
+                  className="flex-1"
+                  onClick={timer.reset}
                 >
-                  {isFullscreen ? (
-                    <Minimize className="size-5" />
-                  ) : (
-                    <Maximize className="size-5" />
-                  )}
+                  リセット
                 </Button>
-              )}
+              </div>
+              <div className="flex gap-3">
+                <Button
+                  type="button"
+                  size="lg"
+                  variant="outline"
+                  className="flex-1 gap-2"
+                  onClick={playBell}
+                >
+                  <Bell className="size-5" />
+                  ベルを鳴らす
+                </Button>
+                {fullscreenSupported && (
+                  <Button
+                    type="button"
+                    size="lg"
+                    variant="outline"
+                    onClick={toggleFullscreen}
+                    aria-label={isFullscreen ? "全画面を終了" : "全画面表示"}
+                  >
+                    {isFullscreen ? (
+                      <Minimize className="size-5" />
+                    ) : (
+                      <Maximize className="size-5" />
+                    )}
+                  </Button>
+                )}
+              </div>
             </div>
           </div>
         ) : (

--- a/src/app/timekeep/page.tsx
+++ b/src/app/timekeep/page.tsx
@@ -9,7 +9,6 @@ import {
   SheetDescription,
   SheetHeader,
   SheetTitle,
-  SheetTrigger,
 } from "@/components/ui/sheet";
 import { TALK_TYPE } from "@/constants/timetable";
 import { cn } from "@/lib/utils";
@@ -131,13 +130,6 @@ export default function TimekeepPage() {
         </header>
 
         <Sheet open={pickerOpen} onOpenChange={setPickerOpen}>
-          <SheetTrigger asChild>
-            <Button type="button" variant="outline" className="w-full">
-              {active
-                ? "セッション・時間を変更する"
-                : "セッション・時間を設定する"}
-            </Button>
-          </SheetTrigger>
           <SheetContent
             side="right"
             className="flex w-full max-w-md flex-col gap-4 overflow-y-auto sm:max-w-md"
@@ -282,9 +274,13 @@ export default function TimekeepPage() {
             </div>
           </div>
         ) : (
-          <p className="rounded-xl border border-dashed border-blue-light-300 bg-white p-6 text-center text-sm text-black-400">
+          <button
+            type="button"
+            onClick={openPicker}
+            className="w-full cursor-pointer rounded-xl border border-dashed border-blue-light-300 bg-white p-6 text-center text-sm text-black-400 transition-colors hover:border-blue-light-400 hover:text-blue-light-600"
+          >
             セッションを選ぶか時間を設定するとタイマーが表示されます。
-          </p>
+          </button>
         )}
       </div>
     </main>

--- a/src/app/timekeep/useBell.ts
+++ b/src/app/timekeep/useBell.ts
@@ -18,9 +18,9 @@ const PARTIALS = [
 const MASTER_GAIN = 0.4;
 const ATTACK_SECONDS = 0.002;
 
-// 短い2連打（チンチン）用。減衰を縮め、2発目を少し遅らせて鳴らす。
-const SHORT_DURATION_SCALE = 0.3;
-const SHORT_GAP_SECONDS = 0.4;
+// 2連打（チーン、チーン）用。各打はしっかり響かせつつ、2発目を少し遅らせる。
+const DOUBLE_RING_DURATION_SCALE = 0.7;
+const DOUBLE_RING_GAP_SECONDS = 0.5;
 
 /**
  * Web Audio API で合成したベル音を鳴らすフック。音源ファイルを持たないので
@@ -91,8 +91,8 @@ export function useBell(): Bell {
   const play = useCallback(() => strike(0, 1), [strike]);
 
   const playDouble = useCallback(() => {
-    strike(0, SHORT_DURATION_SCALE);
-    strike(SHORT_GAP_SECONDS, SHORT_DURATION_SCALE);
+    strike(0, DOUBLE_RING_DURATION_SCALE);
+    strike(DOUBLE_RING_GAP_SECONDS, DOUBLE_RING_DURATION_SCALE);
   }, [strike]);
 
   const unlock = useCallback(() => {

--- a/src/app/timekeep/useBell.ts
+++ b/src/app/timekeep/useBell.ts
@@ -18,13 +18,19 @@ const PARTIALS = [
 const MASTER_GAIN = 0.4;
 const ATTACK_SECONDS = 0.002;
 
+// 短い2連打（チンチン）用。減衰を縮め、2発目を少し遅らせて鳴らす。
+const SHORT_DURATION_SCALE = 0.3;
+const SHORT_GAP_SECONDS = 0.25;
+
 /**
  * Web Audio API で合成したベル音を鳴らすフック。音源ファイルを持たないので
  * ライセンス不要・オフラインで動作する。AudioContext は再利用する。
  */
 export type Bell = {
-  /** ベルを鳴らす。 */
+  /** ベルを1回鳴らす。 */
   play: () => void;
+  /** 短いベルを2回鳴らす（チンチン）。 */
+  playDouble: () => void;
   /**
    * AudioContext を生成・再開しておく。ブラウザの自動再生制限を避けるため、
    * 0秒での自動再生に備えてユーザー操作（スタート押下など）の中で呼ぶ。
@@ -53,33 +59,45 @@ export function useBell(): Bell {
     return ctx;
   }, []);
 
-  const play = useCallback(() => {
-    const ctx = ensureCtx();
-    if (!ctx) return;
+  // 1打分のベルを startOffset 秒後にスケジュールする。
+  const strike = useCallback(
+    (startOffset: number, durationScale: number) => {
+      const ctx = ensureCtx();
+      if (!ctx) return;
 
-    const now = ctx.currentTime;
-    const master = ctx.createGain();
-    master.gain.value = MASTER_GAIN;
-    master.connect(ctx.destination);
+      const now = ctx.currentTime + startOffset;
+      const master = ctx.createGain();
+      master.gain.value = MASTER_GAIN;
+      master.connect(ctx.destination);
 
-    for (const partial of PARTIALS) {
-      const osc = ctx.createOscillator();
-      const gain = ctx.createGain();
-      osc.type = "sine";
-      osc.frequency.value = FUNDAMENTAL_HZ * partial.ratio;
-      gain.gain.setValueAtTime(0, now);
-      gain.gain.linearRampToValueAtTime(partial.gain, now + ATTACK_SECONDS);
-      gain.gain.exponentialRampToValueAtTime(0.0001, now + partial.decay);
-      osc.connect(gain);
-      gain.connect(master);
-      osc.start(now);
-      osc.stop(now + partial.decay + 0.05);
-    }
-  }, [ensureCtx]);
+      for (const partial of PARTIALS) {
+        const decay = partial.decay * durationScale;
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = "sine";
+        osc.frequency.value = FUNDAMENTAL_HZ * partial.ratio;
+        gain.gain.setValueAtTime(0, now);
+        gain.gain.linearRampToValueAtTime(partial.gain, now + ATTACK_SECONDS);
+        gain.gain.exponentialRampToValueAtTime(0.0001, now + decay);
+        osc.connect(gain);
+        gain.connect(master);
+        osc.start(now);
+        osc.stop(now + decay + 0.05);
+      }
+    },
+    [ensureCtx],
+  );
+
+  const play = useCallback(() => strike(0, 1), [strike]);
+
+  const playDouble = useCallback(() => {
+    strike(0, SHORT_DURATION_SCALE);
+    strike(SHORT_GAP_SECONDS, SHORT_DURATION_SCALE);
+  }, [strike]);
 
   const unlock = useCallback(() => {
     ensureCtx();
   }, [ensureCtx]);
 
-  return { play, unlock };
+  return { play, playDouble, unlock };
 }

--- a/src/app/timekeep/useBell.ts
+++ b/src/app/timekeep/useBell.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+const FUNDAMENTAL_HZ = 880;
+
+// ベルらしい非整数次倍音の重ね合わせ。{ 周波数比, 音量, 減衰秒数 }。
+const PARTIALS = [
+  { ratio: 1, gain: 1.0, decay: 2.4 },
+  { ratio: 2.0, gain: 0.5, decay: 1.8 },
+  { ratio: 2.4, gain: 0.35, decay: 1.4 },
+  { ratio: 3.0, gain: 0.25, decay: 1.2 },
+  { ratio: 4.5, gain: 0.15, decay: 0.8 },
+];
+
+const MASTER_GAIN = 0.45;
+const ATTACK_SECONDS = 0.005;
+
+/**
+ * Web Audio API で合成したベル音を鳴らすフック。音源ファイルを持たないので
+ * ライセンス不要・オフラインで動作する。AudioContext は再利用する。
+ */
+export function useBell() {
+  const ctxRef = useRef<AudioContext | null>(null);
+
+  useEffect(() => {
+    return () => {
+      ctxRef.current?.close();
+      ctxRef.current = null;
+    };
+  }, []);
+
+  return useCallback(() => {
+    if (typeof window === "undefined" || !window.AudioContext) return;
+
+    let ctx = ctxRef.current;
+    if (!ctx) {
+      ctx = new AudioContext();
+      ctxRef.current = ctx;
+    }
+    // ユーザー操作で呼ばれる想定。サスペンド中なら再開する。
+    if (ctx.state === "suspended") void ctx.resume();
+
+    const now = ctx.currentTime;
+    const master = ctx.createGain();
+    master.gain.value = MASTER_GAIN;
+    master.connect(ctx.destination);
+
+    for (const partial of PARTIALS) {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = "sine";
+      osc.frequency.value = FUNDAMENTAL_HZ * partial.ratio;
+      gain.gain.setValueAtTime(0, now);
+      gain.gain.linearRampToValueAtTime(partial.gain, now + ATTACK_SECONDS);
+      gain.gain.exponentialRampToValueAtTime(0.0001, now + partial.decay);
+      osc.connect(gain);
+      gain.connect(master);
+      osc.start(now);
+      osc.stop(now + partial.decay + 0.05);
+    }
+  }, []);
+}

--- a/src/app/timekeep/useBell.ts
+++ b/src/app/timekeep/useBell.ts
@@ -22,7 +22,17 @@ const ATTACK_SECONDS = 0.002;
  * Web Audio API で合成したベル音を鳴らすフック。音源ファイルを持たないので
  * ライセンス不要・オフラインで動作する。AudioContext は再利用する。
  */
-export function useBell() {
+export type Bell = {
+  /** ベルを鳴らす。 */
+  play: () => void;
+  /**
+   * AudioContext を生成・再開しておく。ブラウザの自動再生制限を避けるため、
+   * 0秒での自動再生に備えてユーザー操作（スタート押下など）の中で呼ぶ。
+   */
+  unlock: () => void;
+};
+
+export function useBell(): Bell {
   const ctxRef = useRef<AudioContext | null>(null);
 
   useEffect(() => {
@@ -32,16 +42,20 @@ export function useBell() {
     };
   }, []);
 
-  return useCallback(() => {
-    if (typeof window === "undefined" || !window.AudioContext) return;
-
+  const ensureCtx = useCallback(() => {
+    if (typeof window === "undefined" || !window.AudioContext) return null;
     let ctx = ctxRef.current;
     if (!ctx) {
       ctx = new AudioContext();
       ctxRef.current = ctx;
     }
-    // ユーザー操作で呼ばれる想定。サスペンド中なら再開する。
     if (ctx.state === "suspended") void ctx.resume();
+    return ctx;
+  }, []);
+
+  const play = useCallback(() => {
+    const ctx = ensureCtx();
+    if (!ctx) return;
 
     const now = ctx.currentTime;
     const master = ctx.createGain();
@@ -61,5 +75,11 @@ export function useBell() {
       osc.start(now);
       osc.stop(now + partial.decay + 0.05);
     }
-  }, []);
+  }, [ensureCtx]);
+
+  const unlock = useCallback(() => {
+    ensureCtx();
+  }, [ensureCtx]);
+
+  return { play, unlock };
 }

--- a/src/app/timekeep/useBell.ts
+++ b/src/app/timekeep/useBell.ts
@@ -2,19 +2,21 @@
 
 import { useCallback, useEffect, useRef } from "react";
 
-const FUNDAMENTAL_HZ = 880;
+// 呼び出し用の卓上チンベルをイメージした明るい金属音。基音は高め。
+const FUNDAMENTAL_HZ = 1320;
 
-// ベルらしい非整数次倍音の重ね合わせ。{ 周波数比, 音量, 減衰秒数 }。
+// 金属棒（グロッケン）系のモード比。明るく金属的な「チンッ」になる。
+// { 周波数比, 音量, 減衰秒数 }。高次ほど速く減衰させて打撃感を出す。
 const PARTIALS = [
-  { ratio: 1, gain: 1.0, decay: 2.4 },
-  { ratio: 2.0, gain: 0.5, decay: 1.8 },
-  { ratio: 2.4, gain: 0.35, decay: 1.4 },
-  { ratio: 3.0, gain: 0.25, decay: 1.2 },
-  { ratio: 4.5, gain: 0.15, decay: 0.8 },
+  { ratio: 1, gain: 1.0, decay: 1.6 },
+  { ratio: 2.76, gain: 0.6, decay: 1.0 },
+  { ratio: 5.4, gain: 0.4, decay: 0.6 },
+  { ratio: 8.93, gain: 0.25, decay: 0.35 },
+  { ratio: 13.34, gain: 0.12, decay: 0.15 },
 ];
 
-const MASTER_GAIN = 0.45;
-const ATTACK_SECONDS = 0.005;
+const MASTER_GAIN = 0.4;
+const ATTACK_SECONDS = 0.002;
 
 /**
  * Web Audio API で合成したベル音を鳴らすフック。音源ファイルを持たないので

--- a/src/app/timekeep/useBell.ts
+++ b/src/app/timekeep/useBell.ts
@@ -20,7 +20,7 @@ const ATTACK_SECONDS = 0.002;
 
 // 短い2連打（チンチン）用。減衰を縮め、2発目を少し遅らせて鳴らす。
 const SHORT_DURATION_SCALE = 0.3;
-const SHORT_GAP_SECONDS = 0.25;
+const SHORT_GAP_SECONDS = 0.4;
 
 /**
  * Web Audio API で合成したベル音を鳴らすフック。音源ファイルを持たないので

--- a/src/app/timekeep/useTimekeepTimer.ts
+++ b/src/app/timekeep/useTimekeepTimer.ts
@@ -1,0 +1,114 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type TimekeepPhase = "session" | "forced" | "ended";
+
+/** セッション終了後、一律で確保する「強制終了まで」の猶予時間（分）。 */
+export const FORCED_TERMINATION_MINUTES = 2;
+const FORCED_TERMINATION_SECONDS = FORCED_TERMINATION_MINUTES * 60;
+
+export type TimekeepTimer = {
+  phase: TimekeepPhase;
+  /** 現在のフェーズの残り秒数。 */
+  remainingSeconds: number;
+  /** 現在のフェーズの総秒数（プログレス表示用）。 */
+  phaseTotalSeconds: number;
+  isRunning: boolean;
+  start: () => void;
+  pause: () => void;
+  reset: () => void;
+};
+
+/**
+ * セッションの持ち時間をカウントダウンし、0 になったら一律で
+ * 「強制終了まで2分」のカウントダウンへ自動的に切り替えるタイマー。
+ *
+ * 残り時間は実時刻（Date.now）からの差分で計算するため、タブが非アクティブに
+ * なってもズレが蓄積しない。
+ */
+export function useTimekeepTimer(
+  sessionMinutes: number,
+  resetKey?: string,
+): TimekeepTimer {
+  const sessionSeconds = Math.max(0, Math.round(sessionMinutes * 60));
+
+  const [phase, setPhase] = useState<TimekeepPhase>("session");
+  const [remainingSeconds, setRemainingSeconds] = useState(sessionSeconds);
+  const [isRunning, setIsRunning] = useState(false);
+
+  // 実行中のフェーズが 0 になる実時刻（epoch ms）。停止中は null。
+  const deadlineRef = useRef<number | null>(null);
+
+  // セッション（持ち時間 or 選択中のセッション）が変わったら初期状態へ戻す。
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resetKey の変化でリセットしたい。
+  useEffect(() => {
+    setPhase("session");
+    setRemainingSeconds(sessionSeconds);
+    setIsRunning(false);
+    deadlineRef.current = null;
+  }, [sessionSeconds, resetKey]);
+
+  useEffect(() => {
+    if (!isRunning) return;
+
+    const tick = () => {
+      const deadline = deadlineRef.current;
+      if (deadline === null) return;
+
+      const remaining = Math.ceil((deadline - Date.now()) / 1000);
+      if (remaining > 0) {
+        setRemainingSeconds(remaining);
+        return;
+      }
+
+      if (phase === "session") {
+        deadlineRef.current = deadline + FORCED_TERMINATION_SECONDS * 1000;
+        setPhase("forced");
+        setRemainingSeconds(FORCED_TERMINATION_SECONDS);
+        return;
+      }
+
+      // forced -> ended
+      deadlineRef.current = null;
+      setPhase("ended");
+      setRemainingSeconds(0);
+      setIsRunning(false);
+    };
+
+    tick();
+    const id = setInterval(tick, 250);
+    return () => clearInterval(id);
+  }, [isRunning, phase]);
+
+  const start = useCallback(() => {
+    if (isRunning || phase === "ended") return;
+    deadlineRef.current = Date.now() + remainingSeconds * 1000;
+    setIsRunning(true);
+  }, [isRunning, phase, remainingSeconds]);
+
+  const pause = useCallback(() => {
+    deadlineRef.current = null;
+    setIsRunning(false);
+  }, []);
+
+  const reset = useCallback(() => {
+    deadlineRef.current = null;
+    setIsRunning(false);
+    setPhase("session");
+    setRemainingSeconds(sessionSeconds);
+  }, [sessionSeconds]);
+
+  const phaseTotalSeconds =
+    phase === "session" ? sessionSeconds : FORCED_TERMINATION_SECONDS;
+
+  return {
+    phase,
+    remainingSeconds,
+    phaseTotalSeconds,
+    isRunning,
+    start,
+    pause,
+    reset,
+  };
+}

--- a/src/utils/getTimekeepSessions.ts
+++ b/src/utils/getTimekeepSessions.ts
@@ -1,0 +1,62 @@
+import { getSessionMasterBySessionId } from "@/constants/sessionMaster";
+import { timetableList } from "@/constants/timetable";
+import type { EventDate, SessionKey, TrackKey } from "@/types/timetable-api";
+import { myTimetable } from "@/utils/myTimetable";
+
+export type TimekeepSession = {
+  id: string;
+  title: string;
+  speaker: string;
+  day: EventDate;
+  track: TrackKey;
+  trackName: string;
+  sessionType: SessionKey;
+  /** このセッション1本あたりの持ち時間（分）。 */
+  durationMinutes: number;
+  /** セル全体の時間帯（例: "11:10 ~ 11:40"）。 */
+  cellTime: string;
+};
+
+/**
+ * タイムテーブルから各セッションの持ち時間を導出する。
+ *
+ * 1つのセル（時間枠）に複数セッションが入る場合（10分セッション・スポンサー
+ * セッションなど）は、セル全体の長さをセッション数で等分した値を1本あたりの
+ * 持ち時間とする。
+ */
+export function getTimekeepSessions(): TimekeepSession[] {
+  const sessions: TimekeepSession[] = [];
+
+  for (const day of timetableList) {
+    for (const cell of day.cells) {
+      if (cell.content.type !== "session") continue;
+
+      const { sessions: refs, sessionType, displayLabel } = cell.content;
+      const totalMinutes = (cell.endTime - cell.startTime) / 60;
+      const durationMinutes = Math.round(totalMinutes / refs.length);
+      const cellTime = myTimetable.formatTimeRange(
+        cell.startTime,
+        cell.endTime,
+      );
+      const track = cell.trackKeys[0];
+      const trackName = day.trackRecord[track].name;
+
+      for (const ref of refs) {
+        const master = getSessionMasterBySessionId(ref.id);
+        sessions.push({
+          id: ref.id,
+          title: master?.title ?? displayLabel ?? `セッション ${ref.id}`,
+          speaker: master?.speaker.name ?? "",
+          day: day.day,
+          track,
+          trackName,
+          sessionType,
+          durationMinutes,
+          cellTime,
+        });
+      }
+    }
+  }
+
+  return sessions;
+}


### PR DESCRIPTION
タイムテーブルのセッション情報から1本あたりの持ち時間を導出してカウントダウンし、
0になったら一律で「強制終了まで2分」のカウントダウンに切り替える /timekeep を追加。

https://claude.ai/code/session_018aNrTDUkcojYNcjmpkBn58