### PR TITLE
feat: セッション詳細ページに登壇資料のリンクを表示

### DIFF
--- a/scripts/data/speakers.json
+++ b/scripts/data/speakers.json
@@ -3,7 +3,7 @@
     "id": "yuki-terashima",
     "title": "TanStack StartのcreateServerFnで作る、型が通るAPI",
     "overview": "TanStack StartのcreateServerFnを用いることで、フロントエンドとバックエンドの境界を越えて型安全なアプリケーションを構築できます。\r\n\r\n一方で、公式ドキュメントやサンプルを読んでも、設計の意図や使い分けの判断基準が分かりづらく、どのように活用すればよいか迷う場面も少なくありません。\r\n\r\n本セッションでは、最小構成のサンプルをもとにcreateServerFnを用いた型安全なAPI設計の基本パターンと、実装時に陥りやすい落とし穴を整理します。\r\n\r\nさらに、TanStack Startのloaderやスキーマ設計との連携を通じて、型が通る状態を継続的に維持するための実践的な指針を紹介します。",
-    "slidesLink": "",
+    "slidesLink": "https://www.docswell.com/s/yt4/Z8NMGQ-tskaigi-2026-create-server-fn",
     "speaker": {
       "name": "Yuki Terashima",
       "userIcon": "x",
@@ -43,7 +43,7 @@
     "id": "kanon",
     "title": "Road to contributor of Valibot - ValibotにISBN validationを追加するまで -",
     "overview": "みなさん、Valibot 使っていますか？\r\n\r\nValibotとはTypeScript 用のスキーマライブラリです。データ構造を定義してデータをバリデーションすることができます。\r\n同様のライブラリにはZodやArkTypeなどがあります。\r\n\r\nそんななかでも私はValibotにISBNをバリデーションする機能のPRを送り、見事マージされました。\r\nhttps://github.com/open-circle/valibot/pull/1097\r\n\r\nこのセッションでは以上の経験をもとに、以下の内容を10分に詰め込んでお話ししたいと思います。\r\n\r\n- 簡単にValibotの使い方などの紹介\r\n- Valibotの内部実装はどうなっているのか？\r\n- ISBNの仕様について\r\n- (Valibotに限らず)スキーマライブラリにどういったFeature Requestを送るとマージされやすいか",
-    "slidesLink": "",
+    "slidesLink": "https://blog.inorinrinrin.com/entry/2026/05/22/140140",
     "speaker": {
       "name": "Kanon",
       "userIcon": "x",
@@ -163,7 +163,7 @@
     "id": "hal",
     "title": "checker.tsにチキンレースを仕掛けてみた：型エラー(TS2589)が発生する境界線を求めて",
     "overview": "Type instantiation is excessively deep and possibly infinite.: ts-plugin(2589)’\r\n\r\n型が複雑すぎたり再帰呼び出しが無限ループしている際によく起きると言われているこの型エラー。\r\nネット上では「anyで回避しよう！」や「型の注釈で解消できます」など、多くのワークアラウンドが提示されていました。\r\n\r\nしかし、私はふと疑問に思いました。\r\n「コンパイラが『無限』と呼ぶ境界線はどこにあるのだろう」と…。\r\n\r\nそこで私はchecker.tsにチキンレースを仕掛けることにしました。\r\n\r\n本セッションではTS2589を発生させる「3つの門番（instantiationDepth / instantiationCount / tailCount）」の正体と、コンパイラによる「型の複雑さ」の定義を紐解きます。\r\n\r\nそして『無限』の境界線の向こう側で私たちを待つ衝撃のラストとは…\r\n\r\nTS2589を正しく理解し、『無限』を味方につけるための10分間をお届けします。",
-    "slidesLink": "",
+    "slidesLink": "https://x.com/hal_spidernight/status/2057691675749646520?s=46",
     "speaker": {
       "name": "Hal",
       "userIcon": "x",
@@ -263,7 +263,7 @@
     "id": "naoaki-kitagawa",
     "title": "権限チェックの一貫性を型で守る TypeScript による多層防御",
     "overview": "私たちのプロダクトでは、ユーザーがテーブルやワークフローなどのリソースをフォルダ階層の中に自由に構築できるデータベースシステムを提供しています。\r\nこの柔軟性から認可の設計は複雑になり、「誰が」「どのリソースに」「何をできるか」を階層構造に沿って制御する必要があります。\r\nこの権限チェックはフロントエンド・バックエンド・データベースの全レイヤーに及ぶため、あるレイヤーで分岐の修正を忘れる「静かなバグ」が生まれやすく、テストもすり抜けがちです。\r\n\r\n本セッションでは、権限アクションの SSoT を定義し、TypeScript における型レベルの制約や網羅性チェックを組み合わせることで、システム全体で権限チェックの一貫性を保つアーキテクチャを紹介します。",
-    "slidesLink": "",
+    "slidesLink": "https://speakerdeck.com/mnch/quan-xian-tietukuno-guan-xing-woxing-deshou-ru-typescript-niyoruduo-ceng-fang-yu",
     "speaker": {
       "name": "北川 直昭",
       "userIcon": "github",
@@ -343,7 +343,7 @@
     "id": "pvcresin",
     "title": "関係性から理解する\"同一性\"の型用語たち",
     "overview": "TypeScriptの話題において、nominal / structural / branded / opaque / phantomといった型に関する用語を見かける機会が増えてきました。\r\nしかし、これらの違いや関係性を説明しようとすると曖昧になりがちです。\r\n私自身も「なんとなく分かったつもり」で流してしまった過去があり、後からうまく説明できずに後ろめたさを感じる場面がありました。\r\n本発表ではTypeScriptが構造的型付けであることを起点に、型の同一性に関するこれらの用語を、コード例を交えて紹介します。\r\nそのうえで、これらの違いと関係性を理解し、解説記事や議論を追える状態を目指します。",
-    "slidesLink": "",
+    "slidesLink": "https://speakerdeck.com/pvcresin/guan-xi-xing-karali-jie-suru-tong-xing-noxing-yong-yu-tati",
     "speaker": {
       "name": "pvcresin",
       "userIcon": "x",
@@ -483,7 +483,7 @@
     "id": "keisuke-ikeda",
     "title": "JavaScript実装の自作プログラミング言語をTypeScript実装に移行した話",
     "overview": "皆さんはプログラミング言語を自作したことはあるでしょうか？\r\n私は過去にJavaScriptでLispを実装したことがあるのですが、大変でした。\r\n\r\nプログラミング言語の実装は、字句解析・構文解析・評価器などから成り、それぞれが複雑な機能を持ちます。JavaScriptで書いていた頃は、ノードの扱い、予期しないundefinedの混入など、実行してみて初めて気づくバグに何度も悩まされました。\r\n\r\n本セッションでは自作プログラミング言語をJavaScriptで実装したあと、TypeScriptへ移行した実体験、言語実装という複雑なドメインだからこそ浮かび上がるTypeScriptの強みと限界を、具体的なコードとともに紹介します。",
-    "slidesLink": "",
+    "slidesLink": "https://speakerdeck.com/keisukeikeda/48",
     "speaker": {
       "name": "Keisuke Ikeda",
       "userIcon": "x",
@@ -563,7 +563,7 @@
     "id": "hayato-kudoh",
     "title": "静的解析への投資がAI時代のコード品質を支える ── カスタムESLintルールの設計と運用",
     "overview": "私たちのプロダクトでは、エンジニアだけでなくPMやデザイナー・ビジネスチームもバイブコーディングでPRを出しています。\r\n日々多くのPRが作成されますが、それでもコード品質を維持しレビューコストを抑えられているのは、100以上のカスタムESLintルール等を中心とした静的解析基盤があるからです。\r\n\r\n本トークでは、「なぜ標準プラグインでは足りないのか」を整理し、Valibot・Hono・Drizzle・Svelteなど、既存のESLintプラグインではカバーしきれないライブラリ群に対して、プロジェクト固有のガードレールをどのように設計したのかを解説します。\r\nさらに、コードレビューの指摘からESLintルール候補を自動抽出しルール化につなげる仕組みや、CI高速化のための設計、AIによるCIエラー自動修正を試みて見えた限界と教訓についても共有します。\r\n\r\n静的解析への投資がAI時代にどう効くのか、カスタムESLintルールの設計からCI運用まで具体的に共有します。",
-    "slidesLink": "",
+    "slidesLink": "https://speakerdeck.com/hayatokudou/tskaigi2026-jing-de-jie-xi-henotou-zi-gaaishi-dai-nokodopin-zhi-wozhi-eru-kasutamueslintrurunoshe-ji-toyun-yong",
     "speaker": {
       "name": "工藤 颯斗",
       "userIcon": "x",
@@ -703,7 +703,7 @@
     "id": "lacolaco",
     "title": "いつテストを書くか？―ソフトウェア開発における安心と不安について考える",
     "overview": "TypeScriptの型システムは、JavaScript開発の世界に多くの安心をもたらしています。同様に、ソフトウェア開発において安心をもたらすものといえばテストです。その安心は、Agentic Codingが広がる中では、AIを自律的にのびのびと動かすためにも重要になっています。テスト駆動開発にもここ数年でさらに注目が集まっているように思います。\r\n\r\n本セッションは、「安心」をテーマにして、いまあらためてテストについて考える場を作りたいと思います。わたしたちは開発の現場で何に不安を感じているのでしょうか。型やテストはその不安を解消できているでしょうか。どうすればいまよりも安心してソフトウェアを開発できるでしょうか。明確な答えはありませんが、一緒に考えてみませんか？",
-    "slidesLink": "",
+    "slidesLink": "https://bit.ly/tskaigi2026-lacolaco",
     "speaker": {
       "name": "lacolaco",
       "userIcon": "x",
@@ -763,7 +763,7 @@
     "id": "ryutaro-yako",
     "title": "Zod v4 Codec でスキーマに型変換を埋め込む REST API 設計",
     "overview": "REST API 開発ではアプリの型と API レスポンスの型が一致しない場面が多く、たとえば日時はアプリでは Dayjs で扱いたいのに、レスポンスでは ISO 文字列になります。tRPC 等では透過的に解決できますが、既存の REST API を維持したいプロジェクトでは変換レイヤーを手書きしがちではないでしょうか？\r\n\r\n本トークでは Zod v4.1 で導入された Codec 機能を活用し、スキーマに encode / decode の双方向変換を組み込むことで、フロントエンドとバックエンドでバリデーション・レスポンス変換を共有し、さらにバックエンドでは DB 結果からのプロパティ絞り込みまでを一つのスキーマ定義に集約できる実装パターンを、Hono + Drizzle を例にご紹介します！",
-    "slidesLink": "",
+    "slidesLink": "https://speakerdeck.com/ryutaro_yako/zod-v4-codec-desukimanixing-bian-huan-womai-meip-mu-rest-api-she-ji-number-tskaigi2026",
     "speaker": {
       "name": "Ryutaro Yako",
       "userIcon": "github",
@@ -923,7 +923,7 @@
     "id": "taku-hatano",
     "title": "TypeScriptの型だけでオセロを完全実装する ── 型は\"仕様\"をどこまで語れるか",
     "overview": "TypeScriptで型を用いる際に、型でデータの「形」を記述するだけで終わってしまい、ある条件下で取るべき状態が型に反映されず、不要な型アサーションやランタイムチェックに頼ってしまうことが多々あるように感じています。\r\nそこで今回の発表ではボードゲームのようないくつものルールが重なり合う「仕様」をTypeScriptの型だけで実装することで、型がどこまで仕様を表現できるのかを示します。\r\nこのセッションを通じて「こんな仕様も表現できるなら自分たちのプロダクトでも活用できるかも」と感じていただくことが大きな目的です。\r\n\r\n本発表では実装対象として「オセロ」を選択し、合法手の判定、石の反転、盤面の進行、勝敗判定といったルールを型のみで表現します。\r\nさらに、型名や文脈を伏せた状態でこの型定義をAIに与え、「これは何のルールを表している型か？」と推論させる実験も行います。\r\nその結果から型がどれほど「仕様の意味」を保持しうるのかも考察します。\r\n\r\n本セッションを通じて、TypeScriptの型を「値の形を記述する道具」から「仕様そのものを記述する言語」へと捉え直す視点を提示します。",
-    "slidesLink": "",
+    "slidesLink": "https://speakerdeck.com/forcia/typescriptnoxing-dakedeoserowowan-quan-shi-zhuang-suru-xing-ha-shi-yang-wodokomadeyu-reruka",
     "speaker": {
       "name": "籏野 拓",
       "userIcon": "github",
@@ -1003,7 +1003,7 @@
     "id": "tatsukawa",
     "title": "TypeScriptとAngular Signal で実現する保守性の高いアプリケーション設計 - 3層アーキテクチャによる責務分離の実践",
     "overview": "Component 内にすべてのロジックを実装すると、ビジネスロジック、状態管理、API 呼び出しが混在し、コードの可読性とテスタビリティが低下する課題があります。本トークでは、プレゼンテーション層・ユースケース層・データアクセス層の3層アーキテクチャを導入し、各層の責務を明確に分離することで保守性を向上させた事例を紹介します。特に、Writable signals と Computed signals による状態管理のカプセル化、各層の責務範囲の明確化、TypeScript の型システムを活用した型安全な設計など、実務で直面する具体的な課題への実践的なアプローチをコード例と共に紹介します。",
-    "slidesLink": "",
+    "slidesLink": "https://speakerdeck.com/nealle/typescript-angular-signal-structure",
     "speaker": {
       "name": "たつかわ",
       "userIcon": "x",
@@ -1283,7 +1283,7 @@
     "id": "nabeliwo",
     "title": "React の props は値の集合ではない — UI の状態を宣言するコンポーネント設計",
     "overview": "React コンポーネントの props 設計は、UI の状態や責務をどれだけ明確に表現できるかに大きく影響します。\r\nしかし実務では、`data` や `isLoading`、`error` といった複数の値の組み合わせによって状態を表現することが多く、コンポーネントが取りうる状態や振る舞いが props から直感的に読み取れないケースも少なくありません。\r\n本セッションでは、props 設計を見直すことでコンポーネントの分かりやすさを高めていくための考え方を紹介します。\r\nその一例として、discriminated union を用いて props を「値の集合」ではなく「状態そのもの」として表現する設計を取り上げ、条件分岐を減らし、不正な状態を型レベルで防ぐアプローチを解説します。\r\nさらに、コンポーネント分割との関係にも触れながら、props 設計によって UI の構造や責務をどのように表現すると良いのか、その判断軸を整理します。\r\n本セッションを通して、参加者が自分のコンポーネントの props 設計を振り返り、「その設計が UI の状態や責務を適切に表現できているか」を判断できるようになることを目指します。",
-    "slidesLink": "",
+    "slidesLink": "https://nabeliwo.github.io/slides/talks/20260523_tskaigi-2026_react-props",
     "speaker": {
       "name": "nabeliwo",
       "userIcon": "x",
@@ -1363,7 +1363,7 @@
     "id": "ayano",
     "title": "TypeScriptエンジニアのためのWASMランタイム入門：AssemblyScriptから理解するメモリの実態",
     "overview": "TypeScriptは高水準言語であり、その実行時のメモリ構造はJavaScriptエンジンに依存しています。そのため、通常はオブジェクトや配列がどのようにメモリ上に配置されているかを意識する機会はほとんどありません。本トークでは、TypeScriptに近い構文からWebAssemblyを生成するAssemblyScriptを題材に、「高水準なコードが低レイヤーの線形メモリにどのように配置されるか」を具体的に解説します。\r\n\r\n特に以下にフォーカスします：\r\n- WASMの線形メモリモデルの基本\r\n- AssemblyScriptにおけるオブジェクトレイアウトの実態\r\n- classインスタンスがどのようにメモリ上に配置されるか\r\n- 配列（ArrayBuffer / TypedArray含む）の内部構造",
-    "slidesLink": "https://docs.google.com/presentation/d/19XnUtE1SV5bzUqe9HpbvSF2y1soFU7R-mwKVY45CDZI/edit?usp=sharing",
+    "slidesLink": "https://speakerdeck.com/ayanoyuki/28",
     "speaker": {
       "name": "ayano",
       "userIcon": "github",
@@ -1403,7 +1403,7 @@
     "id": "yamanoku",
     "title": "Navigation APIがlib.dom.d.tsに採用されるまでの道のり",
     "overview": "皆さんは「Navigation API」をご存じでしょうか？\r\n\r\nSPAのクライアントサイドルーティングを実現するために使われるHistory APIの後継のWeb APIです。昨年のInteropプロジェクトでの採用を経て、今年1月よりすべての主要ブラウザにて利用可能になりました。\r\n\r\nしかしこのような最新のWeb APIを使おうとしたら型が未定義で、自らinterface Windowを拡張した経験は皆さんはありませんか？\r\n\r\n本セッションでは、Navigation APIの概要を紹介しつつ、普段何気なく利用しているDOM APIがどのようなフローでTypeScriptでの型定義（lib.dom.d.ts）に採用されるのかを解説します。\r\n\r\nこの発表を通じて、Web標準の技術が「型」として届けられるまでの裏側を知り、最新技術をより安全かつ深く理解して扱えるようになることを目指します。",
-    "slidesLink": "",
+    "slidesLink": "https://yamanoku.net/tskaigi-2026/slide",
     "speaker": {
       "name": "yamanoku",
       "userIcon": "github",
@@ -1543,7 +1543,7 @@
     "id": "hacobu",
     "title": "AI Agent に“攻略本”を渡したら、150フォームの移行が回り始めた話",
     "overview": "React Final Form 製の 150 フォームを、React Hook Form + Zod へどう移行し切るか。\r\n私たちは、移行ノウハウを Agent Skills に閉じ込め、AI Agent に“攻略本”として渡すことで、この大規模移行を進めました。\r\n人がアーキテクチャと型を設計し、AI が量をこなす。この分業を成立させるために何を標準化し、どこを人が握るべきだったのか。現場で得た知見を共有します。",
-    "slidesLink": "",
+    "slidesLink": "https://speakerdeck.com/hacobu/deng-tan-zi-liao-gao-qiao-wu-sheng-866032ab-4f83-42b6-a323-44045e73c3a5",
     "speaker": {
       "name": "高橋悟生",
       "userIcon": "x",
@@ -1623,7 +1623,7 @@
     "id": "mosh",
     "title": "TypeScriptで実現する既存APIを活用したリモートMCPサーバー構築",
     "overview": "MCP（Model Context Protocol）とその周辺技術の発展に伴い、国内でもリモートMCPサーバーの活用事例が増えつつあります。一方で、構築に関する実践的な知見は、まだ十分に共有されているとは言えません。\r\n\r\n本セッションでは、TypeScriptを用いてリモートMCPサーバーをどのように迅速かつ実運用を前提とした形で構築したのかをご紹介します。新たにAPIを設計・実装するのではなく、既存のAPI資産を活用し、短期間で実用的な構成を実現しました。\r\n\r\nその過程で得られた知見を、アーキテクチャを中心に設計・実装・運用まで含めた全体像として整理し、実現方法にフォーカスしてお伝えします。また、モノレポやパッケージ管理による既存資産の再利用や、API仕様を起点とした構築など、TypeScriptの特性を活かした設計についても触れます。さらに、ユーザーにとって扱いやすい利用体験の設計についても取り上げます。\r\n\r\nMCPに関心のある方や、これからリモートMCPサーバーの構築を検討している方にとって、構築の一つのパターンとして参考にしつつ、リモートMCPサーバーの全体像を理解できるセッションを目指します。",
-    "slidesLink": "",
+    "slidesLink": "https://speakerdeck.com/soarteclab/tskaigi-2026",
     "speaker": {
       "name": "鈴木翔大",
       "userIcon": "x",

--- a/scripts/lib/session/export-for-frontend.ts
+++ b/scripts/lib/session/export-for-frontend.ts
@@ -18,6 +18,7 @@ function main() {
         title: entry.title,
         ogpTitle: entry.ogpTitle,
         overview: entry.overview,
+        slidesLink: entry.slidesLink,
         speaker: entry.speaker,
       };
     }

--- a/scripts/lib/session/init-master.ts
+++ b/scripts/lib/session/init-master.ts
@@ -17,17 +17,16 @@ function main() {
     fs.readFileSync(SPEAKERS_JSON, "utf-8"),
   );
 
-  const renamed = data.map(
-    ({ id, slidesLink: _, speaker, title, overview }) => ({
-      speakerId: id,
-      title,
-      overview,
-      speaker: {
-        ...speaker,
-        profileImageUrl: `/speakers/${id}.png`,
-      },
-    }),
-  );
+  const renamed = data.map(({ id, slidesLink, speaker, title, overview }) => ({
+    speakerId: id,
+    title,
+    overview,
+    slidesLink,
+    speaker: {
+      ...speaker,
+      profileImageUrl: `/speakers/${id}.png`,
+    },
+  }));
 
   for (const extraJson of [KEYNOTE_JSON, HANDSON_JSON, OST_JSON]) {
     if (fs.existsSync(extraJson)) {
@@ -38,6 +37,7 @@ function main() {
         speakerId: extra.id,
         title: extra.title,
         overview: extra.overview,
+        slidesLink: extra.slidesLink,
         speaker: {
           ...extra.speaker,
           profileImageUrl: extra.speaker.profileImageUrl,

--- a/scripts/lib/session/types.ts
+++ b/scripts/lib/session/types.ts
@@ -30,4 +30,5 @@ export type MasterEntry = {
   speaker: Speaker;
   id?: string;
   ogpTitle?: string;
+  slidesLink?: string;
 };

--- a/src/app/talks/[id]/TalkContent.tsx
+++ b/src/app/talks/[id]/TalkContent.tsx
@@ -72,7 +72,7 @@ export function TalkContent({
   const { session, sessionType, name, startTime, endTime } = detail;
   const timeRange = myTimetable.formatTimeRange(startTime, endTime);
   const typeLabel = TALK_TYPE[sessionType].name;
-  const { speaker } = session;
+  const { speaker, slidesLink } = session;
 
   return (
     <main className="bg-blue-light-100 pt-16 pb-10 md:py-16 md:px-8 lg:px-10">
@@ -126,6 +126,22 @@ export function TalkContent({
             )}
           </Markdown>
         </div>
+
+        {slidesLink && (
+          <div className="px-6 md:px-8 lg:px-10">
+            <h2 className="text-xl font-bold text-blue-light-500 border-b border-blue-light-500 pb-0.5 w-fit pr-2">
+              登壇資料
+            </h2>
+            <Link
+              href={slidesLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-3 inline-flex items-center text-link-light hover:underline break-all"
+            >
+              {slidesLink}
+            </Link>
+          </div>
+        )}
 
         <div className="mt-4 px-6 md:px-8 lg:px-10">
           <div className="bg-blue-light-200 p-6 rounded-xl">

--- a/src/constants/session-master.json
+++ b/src/constants/session-master.json
@@ -5,6 +5,7 @@
     "title": "ハンズオン",
     "ogpTitle": "ハンズオン",
     "overview": "",
+    "slidesLink": "",
     "speaker": {
       "name": "TSKaigi運営",
       "userIcon": "x",
@@ -26,6 +27,7 @@
     "title": "tscからtsgoへ ── DenoのTypeScript基盤はどう変わったか",
     "ogpTitle": "tscからtsgoへ\n─ DenoのTypeScript基盤はどう変わったか",
     "overview": "2025年3月にMicrosoftが発表したTypeScriptコンパイラのGo移植「tsgo」。Rust製のJavaScript/TypeScriptランタイムであるDenoは、このGo移行にどのように対応したのでしょうか？\r\n本セッションでは、まずDenoがtsgo以前にtscとどのように連携してきたのかを説明します。その後、tsgoに対応するために初期に検討されたcgoによるインプロセス統合案から、最終的に採用されたstdio経由でのプロセス間通信方式への変遷をまとめます。他のRust製ツールが採ったアプローチとも比較しながら、Denoのアーキテクチャ判断について立体的に深掘っていきます。",
+    "slidesLink": "",
     "speaker": {
       "name": "maguro",
       "userIcon": "x",
@@ -47,6 +49,7 @@
     "title": "「関数型プログラミング」を分解する.ts",
     "ogpTitle": "「関数型プログラミング」を分解する.ts",
     "overview": "関数型プログラミングはさまざまなプログラミング言語などに影響を与えてきました。TypeScriptにおいても代数的データ型や純粋性などといった概念が日常的に使われていますし、async/awaitのような機能、Node.jsのfs.readFileといったAPIにも関数型でよく見かける概念が隣り合っています。その一方で、関数型プログラミングはHaskell, OCaml, Scalaといったいわゆる関数型言語でこそ真価を発揮するという主張もあります。実際のところ「関数型プログラミング」という言葉にはあらゆる概念が魔法の箱のように詰め込まれており、とてもTypeScriptでは手の届かないようなテクニックも含まれています。この発表では、そんな関数型プログラミングの手法や概念をいくつか取り上げ、それらの利点やモチベーションからわれわれがTypeScriptでの開発に活かせる点を考えていきます。",
+    "slidesLink": "",
     "speaker": {
       "name": "おーみー",
       "userIcon": "x",
@@ -68,6 +71,7 @@
     "title": "開発体験を左右するライブラリの API 設計 ― GraphQL スキーマ構築ライブラリから考える",
     "ogpTitle": "開発体験を左右するライブラリのAPI設計\n― GraphQLスキーマ構築ライブラリから考える",
     "overview": "TypeScript で GraphQL を実装するためのライブラリには、さまざまな API 設計が存在します。Schema-first と Code-first といったスキーマ記述アプローチの違い、スキーマと TypeScript 型をどのように接続するか、resolver をどのような形で記述させるかといった設計上の選択は、単なる記法の違いではなく、開発者がどのようにスキーマと向き合い、どのように設計を組み立てるかという開発体験そのものを規定します。\r\n\r\n本発表では、既存の GraphQL 実装ライブラリを比較しながら、スキーマ構築と resolver 実装の API 設計を整理します。特に、スキーマと型の結びつけ方や、開発者に与えるメンタルモデルの違いに注目し、それぞれのトレードオフを明らかにします。そのうえで、AI Coding が前提となりつつある現在、ライブラリに求められる API 形状や型情報の役割がどのように変化しうるのかを検討します。整理を踏まえ、新たに開発した GraphQL 実装ライブラリ「gqlkit」の設計を一例として紹介し、今後の GraphQL 実装基盤の方向性を提案します。",
+    "slidesLink": "",
     "speaker": {
       "name": "izumin5210",
       "userIcon": "x",
@@ -89,6 +93,7 @@
     "title": "業務に残された「よくない型」で考える「TypeScriptの難しさ」",
     "ogpTitle": "業務に残された「よくない型」で考える\n「TypeScriptの難しさ」",
     "overview": "TypeScriptがJS環境全般に広がった今、型を使いこなすことはある種当たり前になっています\r\n\r\n一方でふと業務で書いた・書かれたコード振り返ってみると、「一旦諦めてunknown型にしてしまった」「泣く泣くasをしてしまっている」といった場所に心当たりがある人も多いのではないでしょうか？複雑なドメインを扱うコードや、複数人で開発しているコードベースには、そういった「型の妥協点」が少なからず潜んでいます。\r\n\r\n誰も書きたくでasしているわけではないし、unknownで満足してるわけでもない。それでも放置・妥協されたコードには「TSの難しさ」や「TSの限界」を学ぶための重要なヒントが隠されていると思います。\r\n\r\nこのトークでは実際に業務で放置されていた「一般的に良くないとされる型(as/unknown/緩すぎる型)」を収集・パターン化し、「何が難しかったのか」「どう改善できるか」「今のTSの仕組みで解決可能か」を解説します。これらを紐解き、整理する中にはTypeScriptを学ぶ・教える・AIに書かせる上で参考になるポイントが含まれているはずです。\r\n\r\nこのトークではTypeScript初学者の方はもちろん、既に使いこなせている方も含めて「TypeScriptの難しさのパターン」について考える30分を提供します。",
+    "slidesLink": "",
     "speaker": {
       "name": "Saji",
       "userIcon": "github",
@@ -110,6 +115,7 @@
     "title": "関係性から理解する\"同一性\"の型用語たち",
     "ogpTitle": "関係性から理解する\"同一性\"の型用語たち",
     "overview": "TypeScriptの話題において、nominal / structural / branded / opaque / phantomといった型に関する用語を見かける機会が増えてきました。\r\nしかし、これらの違いや関係性を説明しようとすると曖昧になりがちです。\r\n私自身も「なんとなく分かったつもり」で流してしまった過去があり、後からうまく説明できずに後ろめたさを感じる場面がありました。\r\n本発表ではTypeScriptが構造的型付けであることを起点に、型の同一性に関するこれらの用語を、コード例を交えて紹介します。\r\nそのうえで、これらの違いと関係性を理解し、解説記事や議論を追える状態を目指します。",
+    "slidesLink": "https://speakerdeck.com/pvcresin/guan-xi-xing-karali-jie-suru-tong-xing-noxing-yong-yu-tati",
     "speaker": {
       "name": "pvcresin",
       "userIcon": "x",
@@ -131,6 +137,7 @@
     "title": "TypeScriptの「型」をAIのスキルに昇華させてみた件について",
     "ogpTitle": "TypeScriptの「型」を\nAIのスキルに昇華させてみた件について",
     "overview": "TypeScriptの型は従来、静的型チェックによる安全性の確保や入力補完・コードジャンプの支援、またドキュメントとしての役割など幅広く活用されてきました。今回のセッションではAIが普及してきた近年の動向も加味し、さらにもう一歩踏み込んだ型の使い方として、「AIへの動的な指示書の構築」という面で考察していこうと思います。AIのツールを構築する際に、よく手書きでJSONファイルへ定義を書き込んでいく場面があったりしますが、TypeScriptの型やCompiler APIを駆使することで、実際の実装から自動でAIのスキル（MCPなど含め）を構築します。実装したコードの内容からAIがスキルを得て、そのスキルを使ってAIが実装して、さらにそこからスキルを得て…とAIの自走にも繋げられる可能性も秘めており、何より自身の実装がどのようにAIのスキルに繋げられるかという点も楽しみながら、具体例と合わせて見ていきます。",
+    "slidesLink": "",
     "speaker": {
       "name": "higak9",
       "userIcon": "x",
@@ -152,6 +159,7 @@
     "title": "TypeScriptでWebAssemblyを用いた型安全なプラグイン設計",
     "ogpTitle": "TypeScriptでWebAssemblyを用いた\n型安全なプラグイン設計",
     "overview": "他言語で書かれたライブラリや既存資産を活用したい場面は多いものの、実行環境の違いや配布方法、インターフェースの整合性といった課題から、プラグインとして安全に統合することは容易ではありません。特にTypeScriptを中心とした開発では言語境界を越えた拡張機構の設計や、他言語コンポーネントの実務的な扱い方について、共通理解がまだ十分に整理されていないのが現状です。\r\nWebAssemblyは言語非依存の実行形式として、こうした課題への現実的な選択肢になりつつあります。Component ModelやWITといった技術でコンポーネント間のインターフェースを型付きで定義することで、言語を越えた型共有を可能にします。さらにjcoによってブラウザやNode.js環境で実際に利用できる形へ橋渡しすることもできるようになってきています。\r\n本トークでは、Wasmプラグインという具体例を通して、このレイヤー構造と各技術の役割・関係性を整理し、TypeScriptから他言語コンポーネントを利用するまでの流れを実践的に解説します。WebAssemblyを単なる高速化の手段ではなく、既存資産の再利用と拡張性を支える基盤としてどう位置づけるべきかを理解し、今後の技術選択に活かせる視点を持ち帰っていただけます",
+    "slidesLink": "",
     "speaker": {
       "name": "glassmonkey",
       "userIcon": "x",
@@ -173,6 +181,7 @@
     "title": "権限チェックの一貫性を型で守る TypeScript による多層防御",
     "ogpTitle": "権限チェックの一貫性を型で守る\nTypeScriptによる多層防御",
     "overview": "私たちのプロダクトでは、ユーザーがテーブルやワークフローなどのリソースをフォルダ階層の中に自由に構築できるデータベースシステムを提供しています。\r\nこの柔軟性から認可の設計は複雑になり、「誰が」「どのリソースに」「何をできるか」を階層構造に沿って制御する必要があります。\r\nこの権限チェックはフロントエンド・バックエンド・データベースの全レイヤーに及ぶため、あるレイヤーで分岐の修正を忘れる「静かなバグ」が生まれやすく、テストもすり抜けがちです。\r\n\r\n本セッションでは、権限アクションの SSoT を定義し、TypeScript における型レベルの制約や網羅性チェックを組み合わせることで、システム全体で権限チェックの一貫性を保つアーキテクチャを紹介します。",
+    "slidesLink": "https://speakerdeck.com/mnch/quan-xian-tietukuno-guan-xing-woxing-deshou-ru-typescript-niyoruduo-ceng-fang-yu",
     "speaker": {
       "name": "北川 直昭",
       "userIcon": "github",
@@ -194,6 +203,7 @@
     "title": "TypeScriptとAngular Signal で実現する保守性の高いアプリケーション設計 - 3層アーキテクチャによる責務分離の実践",
     "ogpTitle": "TypeScriptとAngular Signalで実現する\n保守性の高いアプリケーション設計\n- 3層アーキテクチャによる責務分離の実践",
     "overview": "Component 内にすべてのロジックを実装すると、ビジネスロジック、状態管理、API 呼び出しが混在し、コードの可読性とテスタビリティが低下する課題があります。本トークでは、プレゼンテーション層・ユースケース層・データアクセス層の3層アーキテクチャを導入し、各層の責務を明確に分離することで保守性を向上させた事例を紹介します。特に、Writable signals と Computed signals による状態管理のカプセル化、各層の責務範囲の明確化、TypeScript の型システムを活用した型安全な設計など、実務で直面する具体的な課題への実践的なアプローチをコード例と共に紹介します。",
+    "slidesLink": "https://speakerdeck.com/nealle/typescript-angular-signal-structure",
     "speaker": {
       "name": "たつかわ",
       "userIcon": "x",
@@ -215,6 +225,7 @@
     "title": "OSSのコードベースにneverthrowを漸進的に導入して、AIにも人間にも優しいエラーハンドリングを実現する",
     "ogpTitle": "OSSのコードベースにneverthrowを漸進的に導入して、AIにも人間にも優しいエラーハンドリングを実現する",
     "overview": "OSSプロダクト「Liam」で実際にtry/catchからneverthrowへ移行した過程を、コードベースを公開しながら共有します。\r\n\r\nまず、なぜneverthrowを導入したのかについて。Liamでは開発にAIコード生成を積極的に活用しています。しかしAIが生成するコードはtry/catchの配置が不安定で、エラーハンドリングの設計の整備にコストが発生していました。関数シグネチャにエラー型が表れるneverthrowを導入し、さらに throw new Error を禁止するカスタムESLintルールを設けることで、AIが生成するコードにもエラー処理を強制できるようになりました。\r\n\r\n漸進的な移行戦略について、過程で得られた実践的なtipsも紹介します。\r\n\r\n- エラー型をErrorに統一した薄いラッパーパッケージの設計\r\n- .andThen() チェーンと isErr() による early returnの実務的な制約の中での使い分け\r\n\r\nLiamはOSSのため、実際に使用されているコードを公開しながら説明させていただきます。本トークが、既存プロジェクトへの導入を検討する方の判断材料になれば幸いです。",
+    "slidesLink": "",
     "speaker": {
       "name": "IkedaNoritaka",
       "userIcon": "x",
@@ -236,6 +247,7 @@
     "title": "型で頑張るプロダクト国際化",
     "ogpTitle": "型で頑張るプロダクト国際化",
     "overview": "# トークの主題\r\n\r\nこのトークでは、Reactアプリケーションの多言語化ライブラリi18next/react-i18nextの実践的なチーム運用と、型を活用した高速な開発サイクルの構築についてお話しします。\r\n\r\n# トークの背景\r\n\r\n私は業務でプロダクトの国際化を担当することになり、プロダクトの開発当初から取り入れられつつも本格的な利用には至っていなかったi18next/react-i18nextの活用を推進しました。\r\nしかし、フレームワークが素の状態だったために開発中に翻訳漏れがたびたび発生するなど、国際化対応の観点が開発体験を阻害していました。\r\nそのような課題を型システムの面からどう対処していったのか、いくつかのアプローチを追ってご紹介します。\r\n\r\n# 想定聴衆\r\n\r\n* これからプロダクトの国際化を進められる方、特にi18next/react-i18nextの採用を検討されている方\r\n* チーム開発における多言語化の運用課題に取り組んでいる方",
+    "slidesLink": "",
     "speaker": {
       "name": "Shotaro Ozawa",
       "userIcon": "x",
@@ -257,6 +269,7 @@
     "title": "checker.tsにチキンレースを仕掛けてみた：型エラー(TS2589)が発生する境界線を求めて",
     "ogpTitle": "checker.tsにチキンレースを仕掛けてみた：\n型エラー(TS2589)が発生する境界線を求めて",
     "overview": "Type instantiation is excessively deep and possibly infinite.: ts-plugin(2589)’\r\n\r\n型が複雑すぎたり再帰呼び出しが無限ループしている際によく起きると言われているこの型エラー。\r\nネット上では「anyで回避しよう！」や「型の注釈で解消できます」など、多くのワークアラウンドが提示されていました。\r\n\r\nしかし、私はふと疑問に思いました。\r\n「コンパイラが『無限』と呼ぶ境界線はどこにあるのだろう」と…。\r\n\r\nそこで私はchecker.tsにチキンレースを仕掛けることにしました。\r\n\r\n本セッションではTS2589を発生させる「3つの門番（instantiationDepth / instantiationCount / tailCount）」の正体と、コンパイラによる「型の複雑さ」の定義を紐解きます。\r\n\r\nそして『無限』の境界線の向こう側で私たちを待つ衝撃のラストとは…\r\n\r\nTS2589を正しく理解し、『無限』を味方につけるための10分間をお届けします。",
+    "slidesLink": "https://x.com/hal_spidernight/status/2057691675749646520?s=46",
     "speaker": {
       "name": "Hal",
       "userIcon": "x",
@@ -278,6 +291,7 @@
     "title": "型の深宇宙へ飛び込め ─ tscを遅くする記述パターンの全解剖 ─",
     "ogpTitle": "型の深宇宙へ飛び込め\n─ tscを遅くする記述パターンの全解剖 ─",
     "overview": "TypeScriptプロジェクトが大きくなるにつれ、型チェックに時間がかかるようになった経験はないでしょうか。その重さの正体は、型の深宇宙に潜んでいます。\r\n本セッションでは、tscの型チェックを著しく遅くするコードパターンに焦点を当てます。\r\n以下のような型がなぜコンパイラに負荷をかけるのかを、@typescript/analyze-traceなどのツールを用いてボトルネックを可視化しながら解説します。\r\n\r\n- 再帰的な条件型\r\n- 巨大なUnion型\r\n- 複雑なMapped Type\r\n\r\n「なんとなく重い」を「なぜ重いか」に変えることで、意識的に型を設計できるエンジニアを増やすことが目標です。\r\n実際の重いコード例と改善後のコードを比較しながら、明日から使える知識をお届けします。",
+    "slidesLink": "",
     "speaker": {
       "name": "dowod",
       "userIcon": "x",
@@ -299,6 +313,7 @@
     "title": "決定論的な型チェックへ：Go 製コンパイラによる10倍速の裏側で --stableTypeOrdering から見える並列化への挑戦",
     "ogpTitle": "決定論的な型チェックへ：\nGo製コンパイラによる10倍速の裏側で\n--stableTypeOrderingから見える並列化への挑戦",
     "overview": "「ロジックとして独立した宣言が，関数の型定義の順序を変更してしまう」\r\nこの挙動は，TypeScript の Type IDs を使用した仕組みによるものです．\r\n\r\nTypeScript 6.0 で --stableTypeOrdering フラグが追加される．このオプションは，上記の問題の解決であるのと同時に，TypeScript 7.0 で実現される「Go言語によるネイティブコンパイラ」へ移行準備の意味合いを持ちます．\r\n\r\nGo言語によるコンパイル高速化のための「並列化」は，Type IDsの仕組みだと，型の処理順序に対する「非決定性」の課題が出てきます．\r\n\r\n本セッションでは，TypeScript 6.0 で導入された --stableTypeOrdering フラグに焦点を当て，以下の構成で話します．\r\n\r\n- なぜ離れた場所の const 宣言が，ユニオン型の並び順を変更してしまうのか\r\n\r\n- なぜ TypeScript 7.0 では Type IDs 順を捨て，「コンテンツに基づく決定論的ソート」を導入したのか\r\n\r\n- チェック速度を最大 25% 犠牲にしてまでも提供されるこのフラグの価値と，移行時に発生しうる推論エラー",
+    "slidesLink": "",
     "speaker": {
       "name": "えーたろー",
       "userIcon": "x",
@@ -320,6 +335,7 @@
     "title": "TypeScriptのclassはなぜこうなったのか — 歴史・落とし穴・そして使いどころを探る",
     "ogpTitle": "TypeScriptのclassはなぜこうなったのか\n— 歴史・落とし穴・そして使いどころを探る",
     "overview": "Java、C#、Goなど他の静的型付け言語のユーザーがTypeScriptのclassに戸惑う理由を、歴史・落とし穴・使いどころの3点から整理します。\r\n\r\n2012年のTypeScript誕生時、classはECMAScriptに存在せず、独自実装が先行しました。ES2015で標準化されて以降、[[Define]] vs [[Set]]論争、useDefineForClassFields、デコレーター標準化など、両仕様統合の歴史的経緯が現在の複雑さを生んでいます。\r\n\r\n本セッションでは、開発者が遭遇する落とし穴を根本原因から体系化します。構造的部分型による異クラス同一視とBranded Typeでの対処、プロトタイプベースOOP由来のthisバインディング問題とアロー関数フィールドのトレードオフ、TypeScriptのprivateが実行時に効かない理由とES #privateとの差、型ガードとしてのinstanceofの限界とDiscriminated Unionによる代替。\r\n\r\nこれらは「構造的部分型」と「実行時型消去」という2特性が他言語の直感に反することに起因します。両者を理解すれば、classを使う場面と避ける場面の判断軸が明確になります。\r\n\r\n最後に、適するケースと避けるケースを整理し、「classをやめよう」ではなく「理解して意識的に選択しよう」と結びます。",
+    "slidesLink": "",
     "speaker": {
       "name": "kosui",
       "userIcon": "x",
@@ -341,6 +357,7 @@
     "title": "アンチパターンを避ける型駆動React最適化",
     "ogpTitle": "アンチパターンを避ける型駆動React最適化",
     "overview": "React 19の登場とともに広く普及したReact Compilerは、コンポーネント最適化のあり方を大きく変えました。これまでuseMemoやuseCallback、React.memoに依存していた手動メモ化は、多くのケースでコンパイラによって自動化されつつあります。\r\n\r\nただし、副作用やミュータブルな操作を含むコードでは最適化は適用されず、その仕組みの理解は依然として重要です。\r\n\r\n本セッションでは、React CompilerがASTとデータフロー解析によって依存関係と副作用を検出し、メモ化境界を決定する仕組みを解説します。また、最適化を阻害するアンチパターンを整理し、TypeScriptの型システムや Biome / Oxc といったツールを用いた検知・防止方法を紹介します。\r\n\r\nさらに、手動メモ化の負担軽減に伴い、設計の重心が「再レンダリング最適化」から「純粋性・副作用分離・責務の明確化」へ移行している点を踏まえ、大規模プロジェクトにおける最新の設計指針も提案します。",
+    "slidesLink": "",
     "speaker": {
       "name": "Kazuya Serizawa",
       "userIcon": "x",
@@ -362,6 +379,7 @@
     "title": "ビジネスモデルから紐解く、AI+型駆動開発",
     "ogpTitle": "ビジネスモデルから紐解くAI+型駆動開発",
     "overview": "ビジネスモデルによって「型の重心」は大きく異なります。\r\n\r\nSaaSのようなUI操作が複雑なプロダクトでは、コンポーネントのProps・状態遷移・権限分岐がアプリケーションの型設計の中心になります。\r\n一方、データプラットフォームやマーケットプレイスでは、外部データのスキーマやドメインモデルこそが型のコアです。\r\n\r\nこのセッションでは、「型の重心」の違いを整理した上で、AIコーディングツールが各パターンでどう活きるか、そしてどこで効かないかを実際の経験を通して、考察します。\r\nAI時代において、型をはじめとした設計の意思決定こそが、開発において人間に残る最も重要な仕事であると仮定し、型駆動開発の実践的な戦略を提案します。",
+    "slidesLink": "",
     "speaker": {
       "name": "omote",
       "userIcon": "x",
@@ -383,6 +401,7 @@
     "title": "Stage 3 Decorators でできること / できないこと",
     "ogpTitle": "Stage 3 Decoratorsで\nできること / できないこと",
     "overview": "デコレータの仕様が Stage 3 に達し、さらに TypeScript に実装されてから数年が経ちましたが、実際に利用されているケースはまだ少ないように思います。\r\n\r\nなぜ Stage 3 のデコレータの採用は限定的なのでしょうか？そもそも Stage 3 のデコレータでは何ができるのでしょうか？\r\n\r\nこの発表では TypeScript における Stage 3 のデコレータについて、できることとできないことを整理しつつ、従来からある実験的なデコレータとの比較や、DI や observable などの具体的なユースケースを交えながら、これらの疑問に対する現時点での回答を考えてみます。",
+    "slidesLink": "",
     "speaker": {
       "name": "susisu",
       "userIcon": "github",
@@ -404,6 +423,7 @@
     "title": "TypeScriptだけでAIエージェントを作る ― フロント・エージェント・インフラのフルスタック実践",
     "ogpTitle": "TypeScriptだけでAIエージェントを作る\n― フロント・エージェント・インフラの\nフルスタック実践",
     "overview": "2026年、AIエージェント開発はもはや一部の専門家だけのものではなくなりました。しかし、いざ開発を始めようとすると「Pythonじゃないとダメ？」「どのフレームワークを選べばいい？」「作ったエージェントをどうやってデプロイする？」と壁にぶつかる方も多いのではないでしょうか。\r\n\r\n本トークでは、普段使い慣れたTypeScriptだけで、フロントエンド・エージェント・サーバー・インフラのすべてを構築する実践手法を紹介します。Claude Agent SDKによるエージェント構築をメインに、AgentCore SDKによるサーバー層、React（Vite）によるフロントエンド、AWS CDKによるインフラ定義までを一気通貫で解説します。\r\n\r\n実際に動くアプリケーションのデモを交えながら、TypeScriptで統一することで得られる型安全性や開発体験の向上、そして開発中に得たTipsもお伝えします。さらに、Strands Agents SDKやMastraといった他のエージェントフレームワークとの比較にも触れ、技術選定の判断材料を提供します。\r\n\r\nAIエージェント開発の世界はPython中心に見えがちですが、TypeScriptエコシステムも急速に充実してきています。「自分たちの武器で戦える」という感覚を持ち帰っていただけるセッションを目指します。",
+    "slidesLink": "",
     "speaker": {
       "name": "福地開",
       "userIcon": "x",
@@ -425,6 +445,7 @@
     "title": "プラグインで拡張されるContextをtype-safeにする難しさと設計判断",
     "ogpTitle": "プラグインで拡張されるContextを\ntype-safeにする難しさと設計判断",
     "overview": "筆者が開発したCLIライブラリGunshiは、コマンドの引数を宣言的にモジュール化し、Contextを通じてコマンド実行を制御します。GunshiのContextはCLI引数の解析結果や解決された値を持ち、TypeScriptでコマンドに宣言した引数の型から推論してtype-safeに扱えます。\r\n\r\nGunshiを拡張していくうちにプラグインシステムを導入しました。プラグインはContextを拡張でき、コマンドモジュールや他のプラグインで拡張されたContextもtype-safeに使えます。\r\n\r\ntype-safeの提供は型チェックによる堅牢性だけでなく、エディタのコード補完といった開発者体験(DX)にも直結します。一方で、プラグインで動的に拡張されるデータに対してtype-safeを保証することは、一般的なアプリケーション開発とは異なる難しさがあります。\r\n\r\n発表では、GunshiとContextの概要、プラグインシステム導入の背景を共有します。また、type-safeなContext拡張のいくつかのアプローチを他のライブラリ/フレームワークの事例を用いながら比較し、Gunshiが採用した設計とトレードオフを解説します。",
+    "slidesLink": "",
     "speaker": {
       "name": "kazupon",
       "userIcon": "x",
@@ -446,6 +467,7 @@
     "title": "密結合なバックエンドから TypeScript のコードを生成する",
     "ogpTitle": "密結合なバックエンドから\nTypeScriptのコードを生成する",
     "overview": "「バックエンドとフロントエンドは疎結合であるべき」——理想はそうですが、現実のプロダクト開発、特に大規模開発やモノリスな構成において、両者は不可分な関係にあります。\r\nAPIレスポンスの変更がフロントエンドを静かに破壊したり、バックエンドの仕様変更への追従に疲弊したりしていませんか？これらは管理されていない「悪い密結合」によって引き起こされます。\r\n\r\nfreee会計では10年以上動き続けるプロダクトを開発する中で、この課題に対し、Rubyのコードを Prism を使って構文解析し、その結果をもとにTypeScriptのコード（型定義など）を生成するアプローチを取りました。\r\nこれにより、「バックエンドの変更が即座にフロントエンドの型エラーとして検知される」ようになり、仕様変更に対する追従コストを劇的に下げることができました。結果として、TypeScriptの強力な型恩恵を受けながら、安心してコード変更を行える状態を実現しています。\r\n\r\n本セッションでは、具体的にどのようにこれを実現しているのかについて、以下の技術的詳細を交えて紹介します。\r\n• Node.js 環境で Prismを用いたRubyコードからのAST抽出と解析\r\n• Rubyの構造をTypeScriptの型システムへマッピングする際の変換ロジック\r\n• 長年の運用で得られた、大規模モノリスにおける型運用の知見",
+    "slidesLink": "",
     "speaker": {
       "name": "kemuridama",
       "userIcon": "github",
@@ -467,6 +489,7 @@
     "title": "TypeSpecで繋ぐ複数プロダクトの型安全 — スキーマ共有による「型契約」の実践",
     "ogpTitle": "TypeSpecで繋ぐ複数プロダクトの型安全\n— スキーマ共有による「型契約」の実践",
     "overview": "2つのプロダクトをTypeScriptでフルスタック構築する中で、TypeSpecを「型契約」の基盤として運用し、スキーマ管理とサービス連携を自動化した事例を紹介します。\r\n\r\nチーム内の開発では、TypeSpecからバリデーション用のZod、APIクライアント、MSWモックを一貫して自動生成するパイプラインを構築しました。これにより手動の同期作業を完全に排除し、フロントエンドとバックエンドの実装を常に型で一致させています。さらにこの仕組みをチーム間の連携にも広げ、一方のサービスが定義したAPIやWebhookのスキーマをnpmパッケージとして共有する体制を整えました。スキーマをドキュメントではなく物理的な「型」として直接参照し合うことで、サービスを跨ぐインターフェースの変更をコンパイルタイムで確実に検知できます。\r\n\r\n複数チームが関わる開発において、いかに「型」を境界のガードレールとして機能させ、認識のズレを未然に防ぐか。その具体的な構成と運用の知見を共有します。",
+    "slidesLink": "",
     "speaker": {
       "name": "mitsui",
       "userIcon": "github",
@@ -488,6 +511,7 @@
     "title": "TypeScriptの型はAIに届いているか？ ― AIコーディングツール検証で見えた届き方の差",
     "ogpTitle": "TypeScriptの型はAIに届いているか？\n― AIコーディングツール検証で見えた届き方の差",
     "overview": "TypeScriptの型システムは型推論・定義元特定・参照追跡といったリッチな構造情報を持ち、IDEではLSP経由で日常的に活用されています。ではAIコーディングツールはどうか。Claude Code・Cursor・GitHub Copilot・Codex・Geminiを調査した結果、型情報の届き方はツールごとに大きく異なり、「届く／届かない」の二択では捉えきれないことが見えてきました。本発表では型情報の「届き方」を整理し、各ツールがどこまで何を見ているのか、LSPなどの手段にどう向き合っているかを比較します。さらに「機能がある」「モデルが使う」「実務で効く」はそれぞれ別、という観点から、型をAIに届かせるための実務的な指針も提示します。",
+    "slidesLink": "",
     "speaker": {
       "name": "shotaro",
       "userIcon": "x",
@@ -509,6 +533,7 @@
     "title": "TanStack StartのcreateServerFnで作る、型が通るAPI",
     "ogpTitle": "TanStack StartのcreateServerFnで作る\n型が通るAPI",
     "overview": "TanStack StartのcreateServerFnを用いることで、フロントエンドとバックエンドの境界を越えて型安全なアプリケーションを構築できます。\r\n\r\n一方で、公式ドキュメントやサンプルを読んでも、設計の意図や使い分けの判断基準が分かりづらく、どのように活用すればよいか迷う場面も少なくありません。\r\n\r\n本セッションでは、最小構成のサンプルをもとにcreateServerFnを用いた型安全なAPI設計の基本パターンと、実装時に陥りやすい落とし穴を整理します。\r\n\r\nさらに、TanStack Startのloaderやスキーマ設計との連携を通じて、型が通る状態を継続的に維持するための実践的な指針を紹介します。",
+    "slidesLink": "https://www.docswell.com/s/yt4/Z8NMGQ-tskaigi-2026-create-server-fn",
     "speaker": {
       "name": "Yuki Terashima",
       "userIcon": "x",
@@ -530,6 +555,7 @@
     "title": "実践TanStack Start: 新規プロダクトを開発して確立した、サーバーとクライアント境界の設計パターン",
     "ogpTitle": "実践TanStack Start:\n新規プロダクトを開発して確立した\nサーバーとクライアント境界の設計パターン",
     "overview": "新規プロダクトでTanStack Startを導入しました。サーバーとクライアントの境界を担うloaderとServer Functionsをどう設計するかが、アプリケーション全体の品質を左右します。\r\n\r\nloaderにデータ取得を集中させると、コンポーネントがルーティング構造に依存し、データ取得の再利用性と変更容易性が下がります。Server Functionsにロジックを集中させると、バリデーションやDB操作やビジネスロジックが混在し、Fat controllerと同じ問題を抱えます。\r\n\r\n本セッションでは、loaderとServer Functionsそれぞれの責務をどう限定し、どこにデータ取得やビジネスロジックを配置したかを、実際のコードと設計の変遷を通じて共有します。TanStack Startでプロダクション開発をする際の設計指針を提供します。",
+    "slidesLink": "",
     "speaker": {
       "name": "Shimmy",
       "userIcon": "x",
@@ -551,6 +577,7 @@
     "title": "TanStack Router の型定義を読み解く",
     "ogpTitle": "TanStack Router の型定義を読み解く",
     "overview": "TypeScript で書かれているルーターは多いですが、型定義を実装に後から被せているだけのものがほとんどです。その場合、存在しないパスへのナビゲーションや検索パラメータの型不一致をコンパイル時に検出することが難しく、実行時まで気づけないことがほとんどです。\r\nTanStack Router はルート定義そのものを TypeScript の型情報の源泉として設計されており、パス・パスパラメータ・検索パラメータ・ローダーの返り値まで、型情報がアプリ全体に伝播します。しかし使う側から見ると、その仕組みは見えにくい部分でもあります。\r\n本発表では TanStack Router の型定義のコードを実際に読み解きながら、型安全ルーティングを支える TypeScript の仕組みを解説します。TypeScript の型システムへの理解を深めるきっかけになれば幸いです。",
+    "slidesLink": "",
     "speaker": {
       "name": "IORI",
       "userIcon": "x",
@@ -572,6 +599,7 @@
     "title": "TypeScriptエンジニアのためのWASMランタイム入門：AssemblyScriptから理解するメモリの実態",
     "ogpTitle": "TypeScriptエンジニアのためのWASMランタイム入門：AssemblyScriptから理解するメモリの実態",
     "overview": "TypeScriptは高水準言語であり、その実行時のメモリ構造はJavaScriptエンジンに依存しています。そのため、通常はオブジェクトや配列がどのようにメモリ上に配置されているかを意識する機会はほとんどありません。本トークでは、TypeScriptに近い構文からWebAssemblyを生成するAssemblyScriptを題材に、「高水準なコードが低レイヤーの線形メモリにどのように配置されるか」を具体的に解説します。\r\n\r\n特に以下にフォーカスします：\r\n- WASMの線形メモリモデルの基本\r\n- AssemblyScriptにおけるオブジェクトレイアウトの実態\r\n- classインスタンスがどのようにメモリ上に配置されるか\r\n- 配列（ArrayBuffer / TypedArray含む）の内部構造",
+    "slidesLink": "https://speakerdeck.com/ayanoyuki/28",
     "speaker": {
       "name": "ayano",
       "userIcon": "github",
@@ -593,6 +621,7 @@
     "title": "Oxlint は ESLint / typescript-eslint を置き換えられるか？",
     "ogpTitle": "Oxlint は ESLint / typescript-eslintを\n置き換えられるか？",
     "overview": "VoidZero構想の核であるRust製Linter「Oxlint」は、2025年に安定版となり、ESLint比で50〜100倍という圧倒的な高速性を実現しました。\r\nしかし、実務のTypeScriptプロジェクトにおいて、typescript-eslintが提供する型情報を用いた解析をどう代替・併用すべきかは、多くのエンジニアが直面する課題です。\r\n\r\n本セッションでは、Type-Aware Lintingのための tsgolint の導入ハードル、メモリ使用量、ルール網羅率といった現状の懸念点を整理します。\r\nその上で、なぜ型解析がパフォーマンスのボトルネックとなるのかを構造的に解説し、既存ESLint環境と比較した定量的・定性的なメリットを提示します。\r\n\r\n「爆速の環境のためにどこまで攻め、どこで妥協すべきか」現場の導入判断の指針をお話しします。",
+    "slidesLink": "",
     "speaker": {
       "name": "藤田 翔雅",
       "userIcon": "github",
@@ -614,6 +643,7 @@
     "title": "Oxlintはいかにしてtsgolintのlint ruleを呼び出しているのか",
     "ogpTitle": "Oxlintはいかにしてtsgolintのlint ruleを\n呼び出しているのか",
     "overview": "Oxlintは、VoidZeroによって開発されている、Rust製の高速なJavaScript / TypeScript Linterです。\r\n既に安定版のv1がリリース済みですが、実は、そこにはTypeScriptの型情報に依存するルールの実装が含まれていません。\r\nその役割を担うtype-aware lintingの実装は、typescript-goベースの別リポジトリである、oxc-project/tsgolintで行われています。\r\ntsgolintを通じてlintを行うことで、Oxlintは `no-floating-promises` などのlint ruleをサポートすることができます。\r\n\r\nつまり、Rust実装であるOxlintから、Go実装のtsgolintを呼び出していることになるのですが、一体これはどのように実装されているかご存知でしょうか？\r\n\r\n本発表では、発表者がOxlintおよびtsgolintの実装を読んで知った、プロセス間通信に基づくOxlintとtsgolintの通信方法についての概要と、tsgolint側にルールを追加する度に必要となるOxlint側での実装について解説を行います。\r\nまた、発表者が、tsgolintにカスタムルールを実装しようとした過程で得た知見についてもお話しします。",
+    "slidesLink": "",
     "speaker": {
       "name": "syumai",
       "userIcon": "github",
@@ -635,6 +665,7 @@
     "title": "Zod v4 Codec でスキーマに型変換を埋め込む REST API 設計",
     "ogpTitle": "Zod v4 Codec でスキーマに型変換を埋め込む REST API 設計",
     "overview": "REST API 開発ではアプリの型と API レスポンスの型が一致しない場面が多く、たとえば日時はアプリでは Dayjs で扱いたいのに、レスポンスでは ISO 文字列になります。tRPC 等では透過的に解決できますが、既存の REST API を維持したいプロジェクトでは変換レイヤーを手書きしがちではないでしょうか？\r\n\r\n本トークでは Zod v4.1 で導入された Codec 機能を活用し、スキーマに encode / decode の双方向変換を組み込むことで、フロントエンドとバックエンドでバリデーション・レスポンス変換を共有し、さらにバックエンドでは DB 結果からのプロパティ絞り込みまでを一つのスキーマ定義に集約できる実装パターンを、Hono + Drizzle を例にご紹介します！",
+    "slidesLink": "https://speakerdeck.com/ryutaro_yako/zod-v4-codec-desukimanixing-bian-huan-womai-meip-mu-rest-api-she-ji-number-tskaigi2026",
     "speaker": {
       "name": "Ryutaro Yako",
       "userIcon": "github",
@@ -656,6 +687,7 @@
     "title": "Road to contributor of Valibot - ValibotにISBN validationを追加するまで -",
     "ogpTitle": "Road to contributor of Valibot\n- ValibotにISBN validationを追加するまで -",
     "overview": "みなさん、Valibot 使っていますか？\r\n\r\nValibotとはTypeScript 用のスキーマライブラリです。データ構造を定義してデータをバリデーションすることができます。\r\n同様のライブラリにはZodやArkTypeなどがあります。\r\n\r\nそんななかでも私はValibotにISBNをバリデーションする機能のPRを送り、見事マージされました。\r\nhttps://github.com/open-circle/valibot/pull/1097\r\n\r\nこのセッションでは以上の経験をもとに、以下の内容を10分に詰め込んでお話ししたいと思います。\r\n\r\n- 簡単にValibotの使い方などの紹介\r\n- Valibotの内部実装はどうなっているのか？\r\n- ISBNの仕様について\r\n- (Valibotに限らず)スキーマライブラリにどういったFeature Requestを送るとマージされやすいか",
+    "slidesLink": "https://blog.inorinrinrin.com/entry/2026/05/22/140140",
     "speaker": {
       "name": "Kanon",
       "userIcon": "x",
@@ -677,6 +709,7 @@
     "title": "Navigation APIがlib.dom.d.tsに採用されるまでの道のり",
     "ogpTitle": "Navigation APIがlib.dom.d.tsに\n採用されるまでの道のり",
     "overview": "皆さんは「Navigation API」をご存じでしょうか？\r\n\r\nSPAのクライアントサイドルーティングを実現するために使われるHistory APIの後継のWeb APIです。昨年のInteropプロジェクトでの採用を経て、今年1月よりすべての主要ブラウザにて利用可能になりました。\r\n\r\nしかしこのような最新のWeb APIを使おうとしたら型が未定義で、自らinterface Windowを拡張した経験は皆さんはありませんか？\r\n\r\n本セッションでは、Navigation APIの概要を紹介しつつ、普段何気なく利用しているDOM APIがどのようなフローでTypeScriptでの型定義（lib.dom.d.ts）に採用されるのかを解説します。\r\n\r\nこの発表を通じて、Web標準の技術が「型」として届けられるまでの裏側を知り、最新技術をより安全かつ深く理解して扱えるようになることを目指します。",
+    "slidesLink": "https://yamanoku.net/tskaigi-2026/slide",
     "speaker": {
       "name": "yamanoku",
       "userIcon": "github",
@@ -698,6 +731,7 @@
     "title": "TypeScriptの型だけでオセロを完全実装する ── 型は\"仕様\"をどこまで語れるか",
     "ogpTitle": "TypeScriptの型だけでオセロを完全実装する\n─ 型は\"仕様\"をどこまで語れるか",
     "overview": "TypeScriptで型を用いる際に、型でデータの「形」を記述するだけで終わってしまい、ある条件下で取るべき状態が型に反映されず、不要な型アサーションやランタイムチェックに頼ってしまうことが多々あるように感じています。\r\nそこで今回の発表ではボードゲームのようないくつものルールが重なり合う「仕様」をTypeScriptの型だけで実装することで、型がどこまで仕様を表現できるのかを示します。\r\nこのセッションを通じて「こんな仕様も表現できるなら自分たちのプロダクトでも活用できるかも」と感じていただくことが大きな目的です。\r\n\r\n本発表では実装対象として「オセロ」を選択し、合法手の判定、石の反転、盤面の進行、勝敗判定といったルールを型のみで表現します。\r\nさらに、型名や文脈を伏せた状態でこの型定義をAIに与え、「これは何のルールを表している型か？」と推論させる実験も行います。\r\nその結果から型がどれほど「仕様の意味」を保持しうるのかも考察します。\r\n\r\n本セッションを通じて、TypeScriptの型を「値の形を記述する道具」から「仕様そのものを記述する言語」へと捉え直す視点を提示します。",
+    "slidesLink": "https://speakerdeck.com/forcia/typescriptnoxing-dakedeoserowowan-quan-shi-zhuang-suru-xing-ha-shi-yang-wodokomadeyu-reruka",
     "speaker": {
       "name": "籏野 拓",
       "userIcon": "github",
@@ -719,6 +753,7 @@
     "title": "TypeScript の型で副作用の実行順序を制御する",
     "ogpTitle": "TypeScript の型で副作用の実行順序を制御する",
     "overview": "バリデーション前にデータを保存する、ログを取らずに重要な処理を実行する、認証前に API を呼ぶ。\r\n副作用を持つ処理では実行順序のミスがデータ破損やセキュリティ問題を引き起こします。\r\nテストを書く前、コードを実行する前に、エディタ上で即座に気づきたい。\r\nこれをコンパイル時に防げないか。\r\n本トークでは、TypeScript の型システムで副作用の実行順序をどこまで制御できるのかを探ります。\r\nまた、純粋関数でもデータの形状を保証するために実行順序の制約が有効であることを示します。",
+    "slidesLink": "",
     "speaker": {
       "name": "yanaemon",
       "userIcon": "x",
@@ -740,6 +775,7 @@
     "title": "「雰囲気tsconfig」からの脱却：pnpmモノレポ運用で学び直したProject Referencesの基礎と実践",
     "ogpTitle": "「雰囲気tsconfig」からの脱却：\npnpmモノレポ運用で学び直した\nProject Referencesの基礎と実践",
     "overview": "pnpm workspacesなどのモノレポ環境で推奨される「Project References」。しかし実態として「とりあえず composite: true にして references を書けばいい」と、”おまじない”のように設定していませんか？\r\n\r\n本トークは、現場のエンジニアが「なぜモノレポでProject Referencesが必要なのか？」をコンパイラの基礎的な挙動に立ち返った解説の実践の共有を主題します。\r\n\r\n単一の巨大な tsconfig.json が引き起こす全ファイルASTパースから、パッケージ境界の .d.ts を活用した参照への変化、そして .tsbuildinfo を用いた差分ビルド（tsc -b）の仕組みを整理します。\r\n\r\nコンパイラの気持ちを少し理解し、自信を持って tsconfig.json を設計・運用できるようになるための、明日から使える基礎知識をお届けします。",
+    "slidesLink": "",
     "speaker": {
       "name": "hedrall",
       "userIcon": "x",
@@ -761,6 +797,7 @@
     "title": "TS 7: How We Got There",
     "ogpTitle": "TS 7: How We Got There",
     "overview": "TypeScript 7 ships soon, powered by a full port of the compiler to Go, bringing 10x faster builds and real concurrency to every TypeScript user. This talk is the story of how we got there: why we couldn't keep going with JavaScript, how we picked Go, and what a year of porting, testing, and shipping previews actually looked like. You'll hear about the strategies that saved us, from snapshot testing and differential fuzzing to testing against thousands of real-world projects, and what we had to give up along the way.",
+    "slidesLink": "",
     "speaker": {
       "name": "Jake Bailey",
       "userIcon": "x",
@@ -782,6 +819,7 @@
     "title": "制約と時代から読み解くTypeScriptコンパイラ設計史",
     "ogpTitle": "制約と時代から読み解く\nTypeScriptコンパイラ設計史",
     "overview": "TypeScript コンパイラの Go 移植の際に話題になったのが「なぜ Rust ではないのか」という問いでした。その障壁の一つとして挙げられたのが、複雑な循環参照と GC 前提の設計です。実際、それをはじめとして TypeScript コンパイラには独特な実装が多くあります。しかし、なぜそもそもそのような設計になっているのかを掘り下げた話はあまり見かけません。\r\n\r\n本セッションでは、開発当時の時代背景や制約、VSCodeとの関係、C# Roslyn など他のコンパイラとの比較、そして関係者の言及を通じて、TypeScript コンパイラの設計判断の背景を読み解きます。その帰結としてGo移植で解消が期待されるポイントにも触れます。\r\n\r\n制約の中でなされた設計判断を知り、「ネイティブでportしたから速くなった」からさらに解像度を上げることを目指します",
+    "slidesLink": "",
     "speaker": {
       "name": "Yoshiaki Togami",
       "userIcon": "github",
@@ -803,6 +841,7 @@
     "title": "400超のデータポイントを型で制す —— UPSIDERの与信審査エンジンを支えるTypeScriptの「柔軟性」と「結合力」",
     "ogpTitle": "400超のデータポイントを型で制す\n— UPSIDERの与信審査エンジンを支える\nTypeScriptの「柔軟性」と「結合力」",
     "overview": "スタートアップの成長を支えるUPSIDERのカード与信審査。その心臓部はNext.js/TypeScriptで構築されています。400を超える膨大なデータポイントを扱い、複雑な計算ロジックが絡み合うこの領域で、なぜ私たちはTypeScriptを選んだのか。\r\n\r\n本セッションでは、フロントエンドとバックエンドを1 Interfaceで統合し、型安全を維持しながら開発スピードを最大化する方法についてご紹介します。特に、実行時（Runtime）のデータインジェクションや、複雑なグローバル設定へのマージ、テスト時におけるデータのオーバーライドなど、動的な性質と堅牢性が求められるロジックにおいて、TypeScriptが他の言語以上に「ビジネスの武器」となる理由を深掘りします。",
+    "slidesLink": "",
     "speaker": {
       "name": "泉雄介",
       "userIcon": "x",
@@ -824,6 +863,7 @@
     "title": "AIのために、AIを使った、Effect-TSからの脱却 〜テストを活用した安全なリファクタリングの進め方〜",
     "ogpTitle": "AIのために、AIを使った、Effect-TSからの脱却\n〜テストを活用した安全なリファクタリング\nの進め方〜",
     "overview": "2024年3月からバックエンドの一部でEffect-TSを導入して運用してきました。Effect-TSの思想は非常に魅力的でありつつも、AIが活躍する現代において「チームでの習熟度を上げることが難しく、AIの成果物をチームで評価することが難しいこと」に課題を感じ、2026年初にEffect-TSから脱却することを決断しました。\r\n\r\nEffect-TSというエコシステムの特性上、影響範囲は非常に広く脱却するには多くの修正が必要でしたが、書籍「レガシーコード改善ガイド」にも記載されているように、まず既存仕様のテストを実装してからリファクタリングする方針をとること、UseCaseやRepository、Domainレイヤごとの戦略や実行順順序をコントロールすること、で安全にAIエージェントを使ってリファクタリングを実施、1つも問題を発生させることなくリリースを完遂させました。\r\n\r\nEffect-TS導入当初から思想は魅力的に感じつつもチームにフィットしない懸念があったため、後から排除することも一定考慮して導入を進めてきました。Effect-TSの良かったことと辛かったこと、アーキテクチャ視点も含めてどのようにEffect-TSを導入したか、そしてどのようにAIを活用して脱却したか、Effect-TSを具体的な例にしつつ、他のリファクタリングにも適用可能な進め方を発表します。",
+    "slidesLink": "",
     "speaker": {
       "name": "佐藤 拓人",
       "userIcon": "x",
@@ -845,6 +885,7 @@
     "title": "React の props は値の集合ではない — UI の状態を宣言するコンポーネント設計",
     "ogpTitle": "React の props は値の集合ではない\n— UI の状態を宣言するコンポーネント設計",
     "overview": "React コンポーネントの props 設計は、UI の状態や責務をどれだけ明確に表現できるかに大きく影響します。\r\nしかし実務では、`data` や `isLoading`、`error` といった複数の値の組み合わせによって状態を表現することが多く、コンポーネントが取りうる状態や振る舞いが props から直感的に読み取れないケースも少なくありません。\r\n本セッションでは、props 設計を見直すことでコンポーネントの分かりやすさを高めていくための考え方を紹介します。\r\nその一例として、discriminated union を用いて props を「値の集合」ではなく「状態そのもの」として表現する設計を取り上げ、条件分岐を減らし、不正な状態を型レベルで防ぐアプローチを解説します。\r\nさらに、コンポーネント分割との関係にも触れながら、props 設計によって UI の構造や責務をどのように表現すると良いのか、その判断軸を整理します。\r\n本セッションを通して、参加者が自分のコンポーネントの props 設計を振り返り、「その設計が UI の状態や責務を適切に表現できているか」を判断できるようになることを目指します。",
+    "slidesLink": "https://nabeliwo.github.io/slides/talks/20260523_tskaigi-2026_react-props",
     "speaker": {
       "name": "nabeliwo",
       "userIcon": "x",
@@ -866,6 +907,7 @@
     "title": "型プラグインシステムの実装に使われるテクニック",
     "ogpTitle": "型プラグインシステムの実装に使われるテクニック",
     "overview": "昨今のTypeScriptライブラリには、ユーザー側でライブラリの型を拡張できる仕組み（型レベルのプラグインシステム）を持つものが増えています。\r\nHonoのMiddlewareでは、Genericsを通じてContextの型を拡張しその型情報を後続のHandlerへと伝播させることで、Middlewareによって追加された値への型安全なアクセスを実現しています。\r\nTanStack Routerでは、生成されたルートの型をグローバルに定義することで、Linkコンポーネントなどで間接的に使用できるようになっています。\r\n\r\n本トークでは、これらのライブラリがGenericsやInterfaceのDeclaration Mergingを使いどのように型プラグインシステムを実装しているのかを解説します。\r\n型プラグインの仕組みを理解したい人や、自作ライブラリに実装したい人に向け、コードの例を交えて説明します。",
+    "slidesLink": "",
     "speaker": {
       "name": "elecdeer",
       "userIcon": "x",
@@ -887,6 +929,7 @@
     "title": "Auth.jsからBetter Authへの移行に見る「型とランタイム」の設計思想の変化",
     "ogpTitle": "Auth.jsからBetter Authへの移行に見る\n「型とランタイム」の設計思想の変化",
     "overview": "フロントエンドの認証において広く使用されていたAuth.jsですが、コアメンテナ達がBetter Authの開発へ移行し注目を集めています。本セッションでは、この移行における「型情報の扱い」の設計思想の変化に焦点を当てます。\r\n\r\nAuth.jsではSessionなどの組み込み型の拡張にModule Augmentationを用いましたが、型定義とランタイムの実装が独立し、型のドリフトが生じることがありました。\r\nBetter Authではこれを避け、ユーザーによる手動の型拡張を廃止しました。代わりに、ランタイム挙動を決める設定オブジェクトから型を推論し、typeof auth.$Infer.Sessionのように実インスタンスから直接型を抽出して利用するアプローチへと変化しています。\r\n\r\n両者を比較し、開発チームの中で「型とランタイム」に対する思想がどう変化したのかを覗き見てみたいと思います。",
+    "slidesLink": "",
     "speaker": {
       "name": "宇根昇汰",
       "userIcon": "x",
@@ -908,6 +951,7 @@
     "title": "ReactとSvelteのその先、Ripple-TS",
     "ogpTitle": "ReactとSvelteのその先、Ripple-TS",
     "overview": "“the elegant TypeScript UI framework” を謳うRipple-TS (ripple)を知っていますか？\r\n\r\nReactやSvelte 5の開発に携わってきたDominic Gannaway氏が「React、Solid、Svelteの優れたところを統合した」として新たに開発したフレームワークです。\r\n\r\nReactやSolidのようにJSXっぽい？\r\nSvelteのようなDSLっぽい？\r\nはたまたJetpack ComposeやSwift UIのよう？\r\n\r\nReactやSvelteを開発した先にはなにが見えるのでしょうか。\r\nRipple-TSの概要と仕組みを見てみましょう。",
+    "slidesLink": "",
     "speaker": {
       "name": "ssssota",
       "userIcon": "github",
@@ -929,6 +973,7 @@
     "title": "LLM時代のリファクタリング戦略：AIエージェントによる段階的・安全なTS移行方法",
     "ogpTitle": "LLM時代のリファクタリング戦略：\nAIエージェントによる段階的・安全なTS移行方法",
     "overview": "「既存の巨大なJavaScriptプロジェクトをTypeScriptへ移行する」——これは多くの開発者が直面する課題です。しかし、LLMと自律型AIエージェントの登場により、この課題のハードルは下がりつつあります。\r\n本セッションでは、Reactで構築された大規模なフロントエンドプロジェクトを、AIエージェントを活用して「段階的」かつ「安全」にTypeScript化した実録とその知見を共有します。\r\n単に型を当てるだけでなく、OpenAPIから生成されたクライアントSDKとAIエージェントをいかに連携させ、コンポーネントやロジックに「意味のある型」を浸透させたのか。\r\nその具体的なプロセスを紹介します。",
+    "slidesLink": "",
     "speaker": {
       "name": "市川 賢",
       "userIcon": "github",
@@ -950,6 +995,7 @@
     "title": "コーディングエージェントはTypeScriptの型エラーをどう自己修正しているのか",
     "ogpTitle": "コーディングエージェントはTypeScriptの\n型エラーをどう自己修正しているのか",
     "overview": "コーディングエージェントが大きく発達し、コード生成後にLanguage Serverからのエラー診断の情報を読み取り、自動的に修正を試みるようになりました。これによって、AIにどう型エラーの情報を正しく伝えるかが関心事になったといえます。\r\n\r\nこの仕組み自体は言語を問わず動作しますが、TypeScriptの型情報がエージェントの修正精度に深く関わってきます。そのため、型設計の基礎がより重要になりそうです。\r\n\r\n本セッションでは、ClineなどOSSの実装から、エージェントが診断情報をどのように活用しているのかを考察します。あわせて、diagnosticsの情報が省略されたり、打ち切りされる仕組みを踏まえ、私たちが型設計で意識できることを考えます。",
+    "slidesLink": "https://docs.google.com/presentation/d/1l2wbXo5TjVHYPinjhT_wHT3v8gdNgJ515TFXhUQS4mg/edit?usp=sharing",
     "speaker": {
       "name": "筧万里/@Melonps",
       "userIcon": "x",
@@ -971,6 +1017,7 @@
     "title": "10秒のビルドを1秒へ：tsdown が切り拓く 2026 年の TypeScript ライブラリ開発",
     "ogpTitle": "10秒のビルドを1秒へ：\ntsdown が切り拓く2026年の\nTypeScriptライブラリ開発",
     "overview": "TypeScript ライブラリの開発において、ビルド時間は開発者の生産性に直結します。本セッションでは、Vite の次世代コアとしても注目される Rust 製バンドラ Rolldown と高速なパーサ Oxc を基盤とした、新進気鋭のビルドツール「tsdown」を徹底解説します。\r\n\r\n従来の tsup と比較して圧倒的なパフォーマンスを実現するアーキテクチャの秘密から、d.ts 生成・複数フォーマット出力といった実用的な機能を紹介し、単なるベンチマーク比較に留まらず既存プロジェクトからのスムーズな移行パスや、開発ワークフローをさらに加速させる実践的な設定方法など、2026 年のライブラリ開発における「新たな強力な選択肢」としての tsdown の活用法を提案します。",
+    "slidesLink": "",
     "speaker": {
       "name": "irie",
       "userIcon": "x",
@@ -992,6 +1039,7 @@
     "title": "JavaScript実装の自作プログラミング言語をTypeScript実装に移行した話",
     "ogpTitle": "JavaScript実装の自作プログラミング言語を\nTypeScript実装に移行した話",
     "overview": "皆さんはプログラミング言語を自作したことはあるでしょうか？\r\n私は過去にJavaScriptでLispを実装したことがあるのですが、大変でした。\r\n\r\nプログラミング言語の実装は、字句解析・構文解析・評価器などから成り、それぞれが複雑な機能を持ちます。JavaScriptで書いていた頃は、ノードの扱い、予期しないundefinedの混入など、実行してみて初めて気づくバグに何度も悩まされました。\r\n\r\n本セッションでは自作プログラミング言語をJavaScriptで実装したあと、TypeScriptへ移行した実体験、言語実装という複雑なドメインだからこそ浮かび上がるTypeScriptの強みと限界を、具体的なコードとともに紹介します。",
+    "slidesLink": "https://speakerdeck.com/keisukeikeda/48",
     "speaker": {
       "name": "Keisuke Ikeda",
       "userIcon": "x",
@@ -1013,6 +1061,7 @@
     "title": "TypeScriptでドット絵エディタ実装録: 状態設計と実装判断",
     "ogpTitle": "TypeScriptでドット絵エディタ実装録：\n状態設計と実装判断",
     "overview": "TypeScript+CanvasAPI利用で開発したWeb上のドット絵エディタを題材としたセッションを行います。\r\n「操作性が良いドット絵エディタをTypeScriptでどう成立させるか」という観点から、機能要件をどのように設計へ落とし込んだかを共有します。\r\nCanvasAPIそのものについてはあまり取り扱いません。\r\n実装時のトレードオフと改善ポイントまでを、実装録として整理して話します。\r\n内容としては基本的な機能（描画・直線等のツール・レイヤー管理）を元に、\r\nレイヤー合成を支える状態管理、線描画や塗りつぶしの実装判断、モバイル向け操作の工夫等の説明を行います。",
+    "slidesLink": "https://docs.google.com/presentation/d/14R6834VcBATfNCyMyQu8oOWdOPjWSvZK/edit?usp=sharing&ouid=106084913462977567989&rtpof=true&sd=true",
     "speaker": {
       "name": "つくだに",
       "userIcon": "x",
@@ -1034,6 +1083,7 @@
     "title": "Real World Effect-TS: 堅牢なプロダクトを型で組み上げる",
     "ogpTitle": "Real World Effect-TS：\n堅牢なプロダクトを型で組み上げる",
     "overview": "Effect-TS は、エラーハンドリング・DI・非同期処理を型レベルで統一的に扱う TypeScript ライブラリです。\r\n本トークでは、Effect-TS を実際に採用した toB SaaS プロダクトを題材に、この仕組みがなぜ従来のエラーハンドリングや DI の手法より強力なのかを、素朴な TypeScript での実装との比較を交えて解説します。\r\nまた、学習コストやテスト戦略といった開発での実態を共有すると同時に、そのトレードオフについて議論し、Effect-TS は本当に必要なのか？という率直な疑問にも向き合います。\r\n\r\nEffect-TS から見いだせる TypeScript の可能性と、現場の経験に基づく実践知の両方を持ち帰れる内容を目指します。",
+    "slidesLink": "",
     "speaker": {
       "name": "asa1984",
       "userIcon": "x",
@@ -1055,6 +1105,7 @@
     "title": "tsserverとは何だったのか、これからどうなるのか",
     "ogpTitle": "tsserverとは\n何だったのか、これからどうなるのか",
     "overview": "TypeScript 7では、Goによる新しい実装への移行に伴い、Language Server Protocol（LSP）を前提として言語サービスが提供される構成へと移行します。\r\n\r\nこれまでTypeScriptのテキストエディタ統合は、tsserverプロセスを通じて提供されるLanguage Service APIを基盤として成立してきました。現在のTypeScriptにおける補完や定義ジャンプといった機能は、この構成の上に成り立っています。\r\n\r\n本セッションでは、従来のtscのAPIアーキテクチャとLanguage Service APIの位置づけを整理し、tsserverとはどのようなものだったのかを振り返ります。また、あまりLSPに馴染みがない開発者にもどのようなプロトコルなのかを簡単に解説したうえで、TypeScript 7においてテキストエディタ統合がどのように変化するのかを整理します。",
+    "slidesLink": "",
     "speaker": {
       "name": "中村遼大",
       "userIcon": "x",
@@ -1076,6 +1127,7 @@
     "title": "TypeScriptでPlatform SDKを作る技術",
     "ogpTitle": "TypeScriptでPlatform SDKを作る技術",
     "overview": "発表者はPaaS（Headless ERP開発プラットフォーム）のTypeScript SDKをゼロから設計・開発しています。\r\n独自のCLIツールやTerraform providerがすでにある中で、より良い開発者体験を目指して生まれたSDKです。\r\n\r\n本発表では、SDK開発において選択した開発者体験とそれを支える技術や実装について紹介します。\r\n\r\n・ユーザー設定に応じた正確な型の提供\r\nビルド済みパッケージにユーザー固有の型情報を後から注入する仕組み\r\n\r\n・実行環境を意識させないコードの書き方\r\n不要コードの排除と、ローカルテストとプラットフォームでの実行を両立するコード変換\r\n\r\n・AIフレンドリーなSDK\r\nLLMにSDKを使った実装問題を解かせて品質を評価するベンチマーク",
+    "slidesLink": "",
     "speaker": {
       "name": "樋口 彰",
       "userIcon": "x",
@@ -1097,6 +1149,7 @@
     "title": "ts-morph でプロジェクト固有のアーキテクチャガードレールを作る",
     "ogpTitle": "ts-morph でプロジェクト固有の\nアーキテクチャガードレールを作る",
     "overview": "アーキテクチャルールへの違反をレビューで毎回指摘したり、AI コーディングエージェントがルールに反したコードを生成してきたり、そんな経験はないでしょうか。ドキュメントにルールを書いても、それは人間にとっても AI にとっても「お願い」でしかなく、コードベースの成長とともに違反は静かに増えていきます。\r\n\r\nESLint のプラグインや、dependency-cruiser などはモジュール間の import 制約を宣言的に定義できますが、ファイルの役割やディレクトリの親子関係に基づく制約となると、カバーしきれないことが多いのが実情です。本セッションでは、ts-morph による TypeScript AST 解析でプロジェクト固有のアーキテクチャルールを CI で自動検出する仕組みを構築した過程を紹介します。実際にツールを導入したところ、対応が追いついていなかった箇所が数十件見つかり、ルールの形骸化を防ぐには自動検出が不可欠だと実感しました。また AI コーディングエージェントへのガードレールとしても活用できています。既存ツールとの使い分けの判断基準から、実装で直面した課題とその解決策まで、具体的なコードとともにお伝えします。",
+    "slidesLink": "",
     "speaker": {
       "name": "msuto / Michimasa Suto",
       "userIcon": "x",
@@ -1118,6 +1171,7 @@
     "title": "typescript-goで変わるリンターの世界 — Flintという第三の選択肢",
     "ogpTitle": "typescript-goで変わるリンターの世界\n— Flintという第三の選択肢",
     "overview": "現在、TypeScriptプロジェクトのリンターはESLintかBiomeの二択が主流です。\r\n\r\nしかし、それぞれに課題があります。\r\n・ESLint：型チェックを伴うルールが遅い\r\n・Biome：カスタムルールの実装にRustの知識が必要\r\n\r\n本発表では、この課題を解決しうる第三の選択肢「Flint」を紹介します。Flintはtypescript-goでパース・型解析を行い、ルールはTypeScriptで記述できるハイブリッドリンターです。ESLintの拡張性とBiomeの速度、両方の良さの両立を目指しています。3ツールの設計思想とベンチマーク比較(Flintは現在アルファ版なので行えない可能性があります)を通じて、2026年のリンター選定の判断軸を説明します。さらに、Flintの実装を題材に、解析処理をGo側に委譲し、ルール実装をTypeScriptで行う構成が、開発体験やパフォーマンスにどのような影響を与えるのかを整理します。\r\n\r\nFlint HP: https://www.flint.fyi/\r\nFlint GitHub: https://github.com/flint-fyi/flint",
+    "slidesLink": "",
     "speaker": {
       "name": "Tamasho Tomoya",
       "userIcon": "github",
@@ -1139,6 +1193,7 @@
     "title": "Polymorphic Components パターンで作る、型安全でセマンティックな UI コンポーネント",
     "ogpTitle": "Polymorphic Components パターンで作る\n型安全でセマンティックなUIコンポーネント",
     "overview": "デザインシステムでコンポーネントを実装する際、決められたスタイルや制約を維持しながらセマンティックな HTML を実現したい場面があります。こうしたケースで有用なのが、レンダリングされる要素を柔軟に選択できる Polymorphic Components パターンです。\r\n本トークでは、このパターンの実装方法を紹介します。あわせて、TypeScript の型システムを活用することで、デザイントークンの補完や、選択した要素に応じた適切な HTML 属性の型チェックといった型安全性の実現方法もご紹介します。",
+    "slidesLink": "",
     "speaker": {
       "name": "ryo",
       "userIcon": "github",
@@ -1160,6 +1215,7 @@
     "title": "Node.js+TypeScriptにおけるCJS/ESM相互運用の最新ポイント",
     "ogpTitle": "Node.js+TypeScriptにおける\nCJS/ESM相互運用の最新ポイント",
     "overview": "2020年にESModuleのネイティブサポートが追加されて以来、Node.jsにおけるCommonJSとESModuleの相互運用は数多くの開発者にとって悩みの種となってきました。2024年10月にrequire(esm)サポートが追加され主要な問題は解決されるには至りましたが、テストフレームワークとの互換性など、依然として注意すべきポイントが存在します。本セッションではCJSとESMの相互運用に関するメカニズムを特にTypeScriptの視点から深掘りし、2026年現在においてどのような対応が不要となり、どのような対応が依然として必要であるかを明らかにしていきます。",
+    "slidesLink": "",
     "speaker": {
       "name": "桐生直輝",
       "userIcon": "x",
@@ -1181,6 +1237,7 @@
     "title": "enum よ、さようなら",
     "ogpTitle": "enumよ、さようなら",
     "overview": "Node.js 22.18 / 23.6 以降、TypeScript ファイルをフラグなしでそのまま実行できるようになりました。ただしこのモードは型アノテーションを「剥がす」だけで、enum・namespace・パラメータプロパティは動作しません。\r\n\r\nTypeScript 5.8 で追加された --erasableSyntaxOnly はこれをコンパイル時に強制するフラグで、「実行時 JS に痕跡を残すような構文は書かせない」という宣言でもあります。\r\n\r\nこの LT では const enum（tsc がインライン展開するため一見 erasable に見えて、実は type-strip ツールには扱えない）との違いを整理しつつ、as const + satisfies による代替パターンも紹介します。今後の TypeScript プロジェクトでどういう構文設計をとるべきか、一緒に考えてみましょう。",
+    "slidesLink": "",
     "speaker": {
       "name": "takuma-ru",
       "userIcon": "x",
@@ -1202,6 +1259,7 @@
     "title": "inferと仲良くなる10分間",
     "ogpTitle": "inferと仲良くなる10分間",
     "overview": "私が最初にinferと出会ったのは、type-challengesの初級に取り掛かったときです。\r\ntype-challengesではこの他にも様々な型を覚えることができますが、今回はinferに絞って紹介します。\r\n\r\n普段フロントエンドエンジニアをしていると、あまりinferを使うことはそう多くないのではないでしょうか。自分もその一人です。\r\n\r\nこのトークでは、infer を「型のパターンマッチにおける変数束縛」という1つのメンタルモデルで捉え直し、基本的な仕組みからTipsを紹介します。",
+    "slidesLink": "",
     "speaker": {
       "name": "infixer",
       "userIcon": "x",
@@ -1223,6 +1281,7 @@
     "title": "AIエージェントと協働するCLI開発 — BunとOpenClawで学んだこと",
     "ogpTitle": "AIエージェントと協働するCLI開発\n— BunとOpenClawで学んだこと",
     "overview": "AIエージェントが日常的に使われる時代に、エージェントが操作しやすいCLIツールの設計はどうあるべきか。本トークでは、BunとTypeScriptを用いたCLIツールの開発・検証を通じて見えてきた「エージェント親和性の高いCLI設計」の知見を共有する。\r\n\r\nBunのネイティブ実行速度・TypeScript直実行・標準APIの充実により、CLIのプロトタイピングが劇的に速くなった。一方でAIエージェントがCLIを操作する場合、出力の機械可読性・エラーハンドリングの明示性・冪等性など、人間向けとは異なる設計上の考慮が必要になる。\r\n\r\n実際にOpenClawのエージェントハーネスをBunで量産する中で得た具体的な知見と、TypeScript/Bunエコシステムがこの文脈でどう活きるかを10分でまとめる。",
+    "slidesLink": "",
     "speaker": {
       "name": "yoshikouki",
       "userIcon": "x",
@@ -1244,6 +1303,7 @@
     "title": "自動レビューエンジンの実装と運用 ~レビューのない世界へ~",
     "ogpTitle": "自動レビューエンジンの実装と運用\n~レビューのない世界へ~",
     "overview": "AIエージェントが世の中に広く普及し、実装が爆速になる一方、PRレビューがボトルネックになりがちという悩みを抱えている人は多いと思います。そのボトルネックを解消する(レビュー自体を無くす)ために、Biome/tsc・gitleaks・osv-scanner・trivy・ast-grep等を1つの品質ゲートに束ね、さらにTypeScript Compiler APIで型・シンボル・参照まで解決して、「フォーマット/静的解析/型/アーキテクチャ/セキュリティ/テスト/スキーマ互換」を機械的に判断するツールを実装し、自分の開発に使ってみました。本発表では、AI実装→自動解析→AIレビューを回す開発サイクル設計で開発を数ヶ月試した所感について話します。",
+    "slidesLink": "",
     "speaker": {
       "name": "Kanato",
       "userIcon": "x",
@@ -1265,6 +1325,7 @@
     "title": "Hono RPCとDrizzle ORMで実現する、AIにも優しいTypeScriptファーストな開発",
     "ogpTitle": "Hono RPCとDrizzle ORMで実現する\nAIにも優しいTypeScriptファーストな開発",
     "overview": "TypeScriptを用いた開発において、バックエンドとフロントエンドのようなレイヤー間の型定義をどうするかは悩ましい課題です。\r\n近年台頭しているHono RPCやtRPCは、以前から使われていたOpenAPIやGraphQLのCode Generatorと違い、コード生成処理を挟むことなく型安全性が担保できます。\r\nこれは人間にとっての開発者体験を向上させるだけでなく、Claude Code等のAIエージェントにとっても大きなメリットをもたらします。\r\n\r\n本セッションでは、先日リリースしたウェブサイトにおいて、Next.js/Hono(Hono RPC)/Drizzle ORMという技術スタックでDBまで含めて一気通貫でTypeScriptファーストなアプローチをとった事例と、その中でのAIツールの活用について紹介いたします。",
+    "slidesLink": "",
     "speaker": {
       "name": "Yudai Shinnoki",
       "userIcon": "x",
@@ -1286,6 +1347,7 @@
     "title": "AI時代に考える、Branded Typesで実現する堅牢な型付け",
     "ogpTitle": "AI時代に考える\nBranded Typesで実現する堅牢な型付け",
     "overview": "AIがコードを生成する今、型の重要性は高まっています。しかし従来の構造的部分型を多用するアプローチでは、ドメインロジックの「意味」を十分に表現できません。そこで本セッションでは、ビジネス上の値の「意味」を型で表現し、ドメインモデルやビジネスロジックの堅牢性と可読性を高めるアプローチについてお話しします。\r\n\r\nBranded Typesというと「引数の渡し間違えを防げる」といったテクニック的な側面が注目されることが多いです。しかし私は、「値の意味（= その値がどんなDomainModelや状態を表しているのか）を型で表現できる」という点に非常に魅力を感じています。\r\n\r\n例えばバリデーション済みのEntityをバリデーション前と区別できたり、同じstringでも異なる概念を明示的に区別することができます。変数名やコードコメントとは異なり、型であるため代入や引数で渡してもその性質が維持されることも大きなメリットです。\r\n\r\n本セッションでは、Branded Typesを活用することでTypeScriptの型安全性を高めることができるアプローチについて説明し、ドメインモデリングに導入することのメリットや従来のアプローチとの違いなどを、実際の経験も交えながらお話しします。",
+    "slidesLink": "",
     "speaker": {
       "name": "池奥裕太/@yuta-ike",
       "userIcon": "x",
@@ -1307,6 +1369,7 @@
     "title": "いつテストを書くか？―ソフトウェア開発における安心と不安について考える",
     "ogpTitle": "いつテストを書くか？\n―ソフトウェア開発における\n安心と不安について考える",
     "overview": "TypeScriptの型システムは、JavaScript開発の世界に多くの安心をもたらしています。同様に、ソフトウェア開発において安心をもたらすものといえばテストです。その安心は、Agentic Codingが広がる中では、AIを自律的にのびのびと動かすためにも重要になっています。テスト駆動開発にもここ数年でさらに注目が集まっているように思います。\r\n\r\n本セッションは、「安心」をテーマにして、いまあらためてテストについて考える場を作りたいと思います。わたしたちは開発の現場で何に不安を感じているのでしょうか。型やテストはその不安を解消できているでしょうか。どうすればいまよりも安心してソフトウェアを開発できるでしょうか。明確な答えはありませんが、一緒に考えてみませんか？",
+    "slidesLink": "https://bit.ly/tskaigi2026-lacolaco",
     "speaker": {
       "name": "lacolaco",
       "userIcon": "x",
@@ -1328,6 +1391,7 @@
     "title": "TypeScriptバックエンドのオブザーバビリティ戦略 — Datadog × NestJSの実践",
     "ogpTitle": "TypeScriptバックエンドのオブザーバビリティ戦略\n— Datadog × NestJSの実践",
     "overview": "NestJS + GraphQL + SQS で構築したTypeScriptバックエンドの本番運用でのオブザーバビリティ戦略を紹介します。構造化ログ基盤（JSON / テキスト切替、コンテキスト自動付与）、APM との統合（trace_id 埋め込みによるログとトレースの紐付け, SQSポーリング処理における span 定義）、ExceptionFilter によるエラーハンドリングと Datadog Error Tracking 連携。TypeScriptバックエンドの「作った後どう監視するか」の運用知見を凝縮してお届けします。TypeScript でバックエンドを運用している方、Datadog をもっと活用したい方に向けた内容です。",
+    "slidesLink": "",
     "speaker": {
       "name": "山本大星",
       "userIcon": "github",
@@ -1349,6 +1413,7 @@
     "title": "次世代リンターで探る、tsgo 時代における型認識カスタムルールの現実解",
     "ogpTitle": "次世代リンターで探る\ntsgo 時代における型認識カスタムルールの現実解",
     "overview": "TypeScript 7.0（tsgo）は、コンパイラを Go で再実装し、最大 10 倍の高速化を実現する一方で、typescript-eslint の型認識カスタムルールの基盤を根本的に覆すことになります。従来の `getTypeChecker()` 経由で JS/TS から直接型情報を取得する方法は、ネイティブ Go プロセスとして動作する tsgo では使用できません。\r\n\r\n本セッションでは、2026 年 4 月時点で確立された手法が存在しない tsgo の型認識カスタムルールについて、その現実解を探ります。\r\nまず、次世代リンター（Oxlint、Rslint、Biome など）の型認識リントに関するアーキテクチャの違いを明確にし、それぞれで型認識カスタムルールの実現可能性を評価します。そこから、tsgolint（Oxlint の型チェックバックエンド）と Rslint 向けに カスタムルールを Go 言語で実装し、独自ビルドしたリンターバイナリで実際に検出できることを確認した Proof-of-Concept を共有します。\r\nさらに、PoC の結果に基づいた tsgo 時代における型認識リントの持続可能な運用戦略について考察します。",
+    "slidesLink": "",
     "speaker": {
       "name": "Yuta Takahashi",
       "userIcon": "github",
@@ -1370,6 +1435,7 @@
     "title": "静的解析への投資がAI時代のコード品質を支える ── カスタムESLintルールの設計と運用",
     "ogpTitle": "静的解析への投資がAI時代のコード品質を支える\n─ カスタムESLintルールの設計と運用",
     "overview": "私たちのプロダクトでは、エンジニアだけでなくPMやデザイナー・ビジネスチームもバイブコーディングでPRを出しています。\r\n日々多くのPRが作成されますが、それでもコード品質を維持しレビューコストを抑えられているのは、100以上のカスタムESLintルール等を中心とした静的解析基盤があるからです。\r\n\r\n本トークでは、「なぜ標準プラグインでは足りないのか」を整理し、Valibot・Hono・Drizzle・Svelteなど、既存のESLintプラグインではカバーしきれないライブラリ群に対して、プロジェクト固有のガードレールをどのように設計したのかを解説します。\r\nさらに、コードレビューの指摘からESLintルール候補を自動抽出しルール化につなげる仕組みや、CI高速化のための設計、AIによるCIエラー自動修正を試みて見えた限界と教訓についても共有します。\r\n\r\n静的解析への投資がAI時代にどう効くのか、カスタムESLintルールの設計からCI運用まで具体的に共有します。",
+    "slidesLink": "https://speakerdeck.com/hayatokudou/tskaigi2026-jing-de-jie-xi-henotou-zi-gaaishi-dai-nokodopin-zhi-wozhi-eru-kasutamueslintrurunoshe-ji-toyun-yong",
     "speaker": {
       "name": "工藤 颯斗",
       "userIcon": "x",
@@ -1391,6 +1457,7 @@
     "title": "柔軟なPDFレイアウトエディタを支える型システム設計 — Discriminated UnionとConditional Typeの実践",
     "ogpTitle": "柔軟なPDFレイアウトエディタを支える\n型システム設計\n— Discriminated UnionとConditional Typeの実践",
     "overview": "バクラク請求書発行では、請求書・見積書・納品書などのPDFレイアウトをGUIで自由にデザインできるビジュアルエディタを提供しています。テキスト・画像・動的テーブルなど6種類のノードを自由に配置し、実際の書類データをバインドしてPDFを生成する仕組みです。\r\n\r\nしかし自由度が高いほど、コードの複雑さも増します。テキストノードにはフォント設定があり、テーブルノードには列定義があり、画像ノードにはフィット方法がある——同じ「ノード」でも中身はまったく別物です。さらにノードの値は固定テキストかもしれないし、書類データから動的に取得するかもしれない。こうした組み合わせの中で「テキストノードなのにテーブルの列定義を参照してしまう」ような取り違えをどう防ぐか。人のレビューに頼るのではなく、型に任せられないか—— 本トークはその問いから始まります。\r\n\r\nProtocol Buffersのoneof定義からZod経由でDiscriminated Unionを自動生成する仕組み、Conditional Typeでノード型名から値型を安全に取り出すパターン、DeepPartialでReducerの部分更新を型安全にする設計、そして同一の型定義でエディタのプレビューとPDF本番生成の両方を駆動するアーキテクチャを、具体的なコードとともに紹介します。",
+    "slidesLink": "",
     "speaker": {
       "name": "minako-ph",
       "userIcon": "x",
@@ -1412,6 +1479,7 @@
     "title": "childrenの順序まで型で縛る ── Branded Typesで実践するJSXの構造安全",
     "ogpTitle": "childrenの順序まで型で縛る\n─ Branded Typesで実践するJSXの構造安全",
     "overview": "JSXのchildrenに何が来るべきか、順序はどうあるべきか、ReactNodeでは全部素通りで、型が構造を守ってくれる世界になっていません。このセッションでは、Branded Typeでコンポーネントのreturn型に「slot名」を付け、childrenをタプル型で制約することで、構造の間違いをコンパイル時に弾くアプローチを紹介します。asアサーションをライブラリ内部に閉じ込めて利用側は何も気にしなくていい設計や、JSX記法だとブランドが消える問題とそのworkaroundにも触れます。",
+    "slidesLink": "",
     "speaker": {
       "name": "Mahito",
       "userIcon": "x",
@@ -1433,6 +1501,7 @@
     "title": "スプレッド構文によるブランド流出問題を乗り越えて、オブジェクト型に対する Branded Types を使い倒す",
     "ogpTitle": "スプレッド構文による\nブランド流出問題を乗り越えて\nオブジェクト型に対するBranded Typesを使い倒す",
     "overview": "TypeScript において公称型を実現するために Branded Types というものがしばしば使われます。異なるエンティティの ID や異なる単位を持つ量の区別といった代表的なユースケースからさらに一歩踏み込んで、オブジェクト型を含む一般的な型についてもブランドを付与して制約を表現することは有益に思えます。ただし、そこにはスプレッド構文によるブランドの流出という罠が潜んでいます。\r\n\r\n本発表では、declare class との交差型によりこのブランド流出問題を解決する方法を提案します。ランタイム性能やシリアライゼーションに懸念のある class を直接取り回すことなく、複雑な型に対しても安全に公称型を実現することが可能になります。",
+    "slidesLink": "",
     "speaker": {
       "name": "tony",
       "userIcon": "x",
@@ -1454,6 +1523,7 @@
     "title": "string地獄を脱出する — ValueObject + Zod 実践パターン",
     "ogpTitle": "string地獄を脱出する\n— ValueObject + Zod 実践パターン",
     "overview": "「string同士の取り違えが本番でしか分からない」「Zodと型定義を二重に書いている」——この2つの悩みを、ValueObject + Zodで解消するパターンを実コードで紹介します。\r\n\r\n数十行の基底クラス ValueObject<T> のコンストラクタでZodを叩き、コンパイル時の型安全とランタイム検証を1箇所に集約する設計です。プリミティブ型VO（z.number().positive().int()で不正値を弾くSystemId）とEnum型VO（z.enumからz.inferで型を導出し二重定義をなくすTaskStatus）の2パターンを実例で解説します。\r\n\r\nまた、プロダクションで113個のValueObjectを運用する中で得た知見として、Plopによる2層構造（Generated層+手動実装層）での効率的な管理手法と、Object型VOのequals問題という実務の落とし穴にも触れます。\r\n\r\n聞くと、型とランタイム検証を一本化する設計パターンと、大量のVOを破綻なく運用する仕組みが持ち帰れます。",
+    "slidesLink": "https://sansan.box.com/s/j4xkoqhxvrcskder3r08t02madbaxcdn",
     "speaker": {
       "name": "高田 理功",
       "userIcon": "x",
@@ -1475,6 +1545,7 @@
     "title": "TypeScript7 - 非推奨設定から読む責務の変化",
     "ogpTitle": "TypeScript7\n- 非推奨設定から読む責務の変化",
     "overview": "TypeScript7 では、従来の JavaScript 実装から Go によるネイティブ実装へ移行し、ビルド速度やエディタ体験が大きく改善されるます。\r\nその一方で 6 系は “7 への橋渡し” として位置づけられており、多数の非推奨設定や挙動変更が段階的に導入されています。\r\n\r\nこれらは単なる設定変更ではなく、「TypeScript が担っていた責務」や「前提」が変わっていることに起因しています。\r\n\r\nそのため放置すると 7 系へのアップグレード時にコンパイルエラーや不整合が発生するだけでなく、なぜ動かないのか分かりにくい状態に陥る可能性があります。\r\n\r\n本セッションでは、非推奨となった設定やコードパターンを単に列挙するのではなく\r\n\r\n・なぜ削除されるのか（設計の変化）\r\n・どのように置き換えるべきか（実務での判断）\r\n\r\nという観点で整理します。\r\n\r\n対象としては target や moduleResolution、tsconfig 周りの設定に加え、React / Vue などのプロジェクトで\r\n影響を受けやすい具体例も取り上げます。\r\n\r\n10 分という短い時間で「理解」と「すぐに使える対応」を持ち帰れる時間にできるように努めます。\r\n当日はよろしくお願いします。",
+    "slidesLink": "",
     "speaker": {
       "name": "Ayu",
       "userIcon": "x",
@@ -1496,6 +1567,7 @@
     "title": "TypeScript Compiler はどのように未使用変数を検出しているのか？",
     "ogpTitle": "TypeScript Compiler は\nどのように未使用変数を検出しているのか？",
     "overview": "TypeScript には `noUnusedLocals` / `noUnusedParameters` といった未使用変数に関するオプションが存在します。\r\n\r\nこれらはどのように変数が未使用であることを検出しているのでしょうか？\r\n\r\n本トークでは、調査過程で得られた知見をもとに、TypeScript Compiler の未使用変数の検出ロジックや、ロジックをどのように紐解いていったかを整理してお伝えしようと思います！\r\n\r\n## 背景\r\n\r\nReact コンポーネントの型付けに関する記事(https://engineering.gusto.com/the-journey-to-a-safer-frontend-why-we-removed-react-fc-095ff0b3e2e4)を読み、引数の型付けの仕方によって TypeScript の未使用変数の検出の挙動が変わるという内容に興味を持ちました。\r\n\r\nそこで、検出の内部的な挙動を理解するために、TypeScript Compiler の実装を実際に追跡して未使用判定がどのような仕組みで行われているのかを調査することにしました。",
+    "slidesLink": "",
     "speaker": {
       "name": "つねみ@tocomi",
       "userIcon": "x",
@@ -1517,6 +1589,7 @@
     "title": "プロパティの順序で型推論が壊れる!? TS6.0 の修正から Context-Sensitivity の仕組みを追う",
     "ogpTitle": "プロパティの順序で型推論が壊れる！？\nTS6.0の修正からContext-Sensitivityの\n仕組みを追う",
     "overview": "TypeScript 6.0 に入った1つの PR を起点に、TypeScript コンパイラの型推論の内部に踏み込むセッションです。\r\n\r\nオブジェクトリテラル内でメソッド構文を使うと、プロパティの記述順序を入れ替えただけでコールバック引数の型が number から unknown に変わる挙動がありました。アロー関数なら順序に関係なく推論が通るのに、メソッド構文にした途端に型推論が壊れていました。\r\n\r\nこの挙動は、型推論における context-sensitive の判定ロジックに起因します。メソッド構文は暗黙の this パラメータを持つため context-sensitive と判定され、推論の処理順が変わります。アロー関数はこれを持たないため、この影響を受けません。\r\n\r\nこの挙動は PR #62243 によって修正され、TS 6.0 でリリースされました。this を実際に使用していない関数を context-sensitive と見なさないよう変更されています。\r\n\r\n本トークではこの PR の差分 (utilities.ts, binder.ts, checker.ts) を追い、変更の意図を読み解きます。この事例を通じて context-sensitivity という概念と、TypeScript の内部に踏み込むきっかけを持ち帰っていただくことを目指します。",
+    "slidesLink": "",
     "speaker": {
       "name": "おおいし (bicstone)",
       "userIcon": "x",
@@ -1538,6 +1611,7 @@
     "title": "Typiaで配信JSONの安全性を構造的に担保する",
     "ogpTitle": "Typiaで配信JSONの安全性を構造的に担保する",
     "overview": "TypeScript における外部入力のバリデーションでは、型定義とバリデーションスキーマの二重管理が課題となりやすい。特に複雑な型を扱う場面では、従来利用していたバリデーションライブラリが型をうまく表現できず、バリデーション用に別途型を定義しなければならないケースがあります。\r\n本発表では、型情報そのものを起点にバリデーションと不要なプロパティの排除を行う Typia を導入し、二重管理を解消した事例を紹介します。移行の背景と実際に行った作業の概要を示したうえで、Typia が複雑な型をどのように扱っているのかを、実装レベルで踏み込んで解説します。",
+    "slidesLink": "",
     "speaker": {
       "name": "oiki",
       "userIcon": "x",
@@ -1559,6 +1633,7 @@
     "title": "バックエンドにElysiaJSを採用して気付いた、良い点・悪い点",
     "ogpTitle": "バックエンドにElysiaJSを採用して気付いた\n良い点・悪い点",
     "overview": "JS/TSのバックエンドフレームワークの一つとして、ElysiaJSというものがあります。\r\nElysiaJSは、State of JavaScript 2025にて「Bun上に構築された唯一のバックエンドフレームワーク」として紹介されており、数あるフレームワークの中でも独自の立ち位置にあります。\r\n皆さん、ElysiaJSがどのような使い心地、書き心地なのか気になりませんか？\r\n\r\n本トークでは、私がElysiaJSを利用して個人開発を行った経験をもとに、ElysiaJSのメリット・デメリットについてお話します。\r\nElysiaJSとはどんなフレームワークなのか、他のフレームワークとはどう違うのか、ElysiaJSを使ったことがない方向けに解説します。\r\n\r\n本トークを通じてElysiaJSの実装例を見ることで、ElysiaJSの全体像を掴むことができます。\r\nさらに、Bunランタイムを前提としたフレームワークの良さ・大変さも押さえつつ、今後のJS/TSの流れをより見通すヒントを得られる時間にします。",
+    "slidesLink": "https://speakerdeck.com/wanko_it/hatukuentonielysiajswocai-yong-siteqi-fu-ita-liang-idian-e-idian",
     "speaker": {
       "name": "わんこ",
       "userIcon": "x",
@@ -1580,6 +1655,7 @@
     "title": "型のないDSLを安全に扱う: TypeScriptとメタプログラミングによるElasticsearch連携の実践",
     "ogpTitle": "型のないDSLを安全に扱う:\nTypeScriptとメタプログラミングによる\nElasticsearch連携の実践",
     "overview": "Elasticsearchは強力な検索エンジンですが、柔軟すぎるJSONベースのクエリDSLは、TypeScript環境下においてはタイポや構造間違いによる実行時エラーを引き起こしやすい課題があります。\r\nまた、インデックスのマッピング定義とアプリケーション層のエンティティ定義の二重管理も、保守性を下げる要因になりがちです。\r\n\r\n本セッションでは、TypeScriptの型システムとメタプログラミングを駆使して、Elasticsearchの動的な振る舞いを型安全に扱うためのアプローチを紹介します。\r\n\r\n具体的には以下の2点を解説します：\r\n1. Template Literal Typesや再帰的な型定義（Recursive Types）を活用し、products.priceOptions.quantity のような深いネストを持つクエリパスをコンパイラに検証させる仕組みの構築\r\n2. デコレータを用いて、アプリケーションのエンティティクラスからElasticsearchのマッピング定義を動的かつ型安全に自動生成し、単一情報源（SSOT）とする手法\r\n\r\n特定のフレームワークに依存せず、外部の動的なDSLやスキーマに対して、TypeScriptの言語機能を活用してどのように静的型検査の恩恵を適用するかという、実プロジェクトでの工夫と知見を共有します。",
+    "slidesLink": "",
     "speaker": {
       "name": "渡邊 耕平",
       "userIcon": "github",
@@ -1601,6 +1677,7 @@
     "title": "ドメインを組織の資産にする — 少人数で複数プロダクトを支えるTypeScript運用の実践",
     "ogpTitle": "ドメインを組織の資産にする\n— 少人数で複数プロダクトを支える\nTypeScript運用の実践",
     "overview": "少人数で10プロダクト以上を運用するASSIGNが、散在していた「型とドメイン」を少しずつ組織の資産として整理してきた3年間の変遷を共有します。\r\nAIがコードを量産できる今、そのスピードを破綻させずに事業へ活かす土台となったのは、型による境界定義や業務語彙といった地道な設計でした。\r\nモノレポによる業務語彙の集約、Zodを用いた仕様の一本化、AI駆動開発の土台作りといった、実践的なTypeScript運用の過程をお伝えします。",
+    "slidesLink": "",
     "speaker": {
       "name": "須永 高弘",
       "userIcon": "x",
@@ -1622,6 +1699,7 @@
     "title": "AI活用の格差をなくす：チーム全体のAI開発生産性を底上げする方法",
     "ogpTitle": "AI活用の格差をなくす：\nチーム全体のAI開発生産性を底上げする方法",
     "overview": "AIツールはすでに多くのエンジニアにとって日常の一部になっています。しかし現場では、使いこなせる人とそうでない人の間で生産性に大きな差が生まれ、チーム全体としては最適化されていないケースが増えています。\r\n\r\nその要因の一つは、AI活用が個人のローカル環境に閉じていることです。プロンプトやノウハウは個人の中に蓄積され、チームとして再利用されないまま分断されています。NotionやIssue管理、コードベースなどに知見は存在しているにもかかわらず、それらはAIと十分に接続されていません。また、プロンプト共有のような取り組みも試みられていますが、文脈依存性が高く、再現性や持続性に課題があります。\r\n\r\n本セッションでは、CodeRabbitのレビュー・実装計画生成・エージェントといった機能を軸に、AI活用が「個人最適」から「チーム最適」へと移行することで何が変わるのかを整理します。GitHub、Notion、Issue管理ツールなどに分散した知識をAIが横断的に扱うことで、レビューの質や開発プロセスがどのように変化するのか、その構造を解説します。",
+    "slidesLink": "",
     "speaker": {
       "name": "中津川篤司",
       "userIcon": "x",
@@ -1643,6 +1721,7 @@
     "title": "Next.js × OpenAPIで型安全なデータ境界を設計するアーキテクチャ改善",
     "ogpTitle": "Next.js×OpenAPIで型安全なデータ境界を設計する\nアーキテクチャ改善",
     "overview": "ウェルスナビではOpenAPIによるスキーマ駆動開発を採用しており、バックエンドにSpring Bootを導入することで、型安全なシステムを構築しています。\r\n\r\n一方、フロントエンドにはNext.jsを採用していますが、開発初期は型を厳密に意識せずUI層とBFF層程度の分割で開発を進めていたため、OpenAPIによるスキーマ駆動開発やSpring Bootが持つ型安全性の恩恵を十分に享受できていませんでした。\r\n\r\nそこで私たちは、Next.jsのBFF層に Data Access Layer（DAL）を新設し、バックエンドの型安全な設計をフロントエンドまで継承し、スキーマ駆動開発による品質および生産性の向上を目的としたリファクタリングを実施しました。\r\n\r\n本セッションでは、DALを設けてUIへ渡すデータの型を明示的に定義し、型安全な「データ境界」を実現したリアーキテクチャの実例を紹介するとともに、実際に運用して感じたメリット・デメリットを紹介します。",
+    "slidesLink": "",
     "speaker": {
       "name": "土本祐介",
       "userIcon": "x",
@@ -1664,6 +1743,7 @@
     "title": "AI Agent に“攻略本”を渡したら、150フォームの移行が回り始めた話",
     "ogpTitle": "AI Agent に\"攻略本\"を渡したら\n150フォームの移行が回り始めた話",
     "overview": "React Final Form 製の 150 フォームを、React Hook Form + Zod へどう移行し切るか。\r\n私たちは、移行ノウハウを Agent Skills に閉じ込め、AI Agent に“攻略本”として渡すことで、この大規模移行を進めました。\r\n人がアーキテクチャと型を設計し、AI が量をこなす。この分業を成立させるために何を標準化し、どこを人が握るべきだったのか。現場で得た知見を共有します。",
+    "slidesLink": "https://speakerdeck.com/hacobu/deng-tan-zi-liao-gao-qiao-wu-sheng-866032ab-4f83-42b6-a323-44045e73c3a5",
     "speaker": {
       "name": "高橋悟生",
       "userIcon": "x",
@@ -1685,6 +1765,7 @@
     "title": "TypeScriptはどのようにどこまで推論できるのか ─ とにかく as は禁止で",
     "ogpTitle": "TypeScriptはどのようにどこまで推論できるのか\n─ とにかく as は禁止で",
     "overview": "TypeScript の型チェックは、型推論、Control Flow 解析、そして各種ガードレールという強力な3つの仕組みに支えられています。そしてInferred Type Predicates (filter()の型推論) のように、以前は手でケアしていた場面でも自動で正しい型が付くようになるなど、これらの機構は年々強化されてきました。\r\n\r\n一方これらの機構でカバーできるにも関わらず as (as constを除く) を使用してしまうことは、AI 時代に必要な安全性を自ら緩めることになり、それは \"敗北\" です。\r\n\r\n本セッションは、Contextual Type をはじめとして、TypeScript の推論機構やガードレールの仕組みと制限を紹介し、その安全性を活かすことにより、「as全部禁止」に対して「主張が強い」と返されないように試みるものです。",
+    "slidesLink": "",
     "speaker": {
       "name": "ypresto",
       "userIcon": "x",
@@ -1706,6 +1787,7 @@
     "title": "AIコーディングエージェントの活用で、コードは静かに肥大化した —— 型・Lint・Skillsで挽回する10分",
     "ogpTitle": "AIコーディングエージェントの活用で\nコードは静かに肥大化した\n— 型・Lint・Skillsで挽回する10分",
     "overview": "近年、CursorやClaude CodeといったAIコーディングエージェントの活用により、TypeScriptプロジェクトの開発サイクルは劇的に加速しました。一方で、高速なイテレーションを繰り返したコードベースは、人間が気づかないうちに構造的な肥大化を招く危険性を孕んでいます。\r\n\r\n本セッションでは、コンパウンド型SaaSのバックエンドをAIと共に1年間育ててきた経験から、重複コード・Fat Usecase・ゴッドメソッドといった「AI由来の負債」に対する3つの防衛策を10分で紹介します。\r\n\r\n具体的には、Discriminated UnionやBranded Typeなどを用いた型による不正状態の排除、ESLintやoxlintによる行数・複雑度の機械的なガード、そしてAgent Skillsを活用したチーム規約のAIへの継承という3つの軸について、実践的な知見を広く浅くお話しします。",
+    "slidesLink": "",
     "speaker": {
       "name": "篠田 陽介",
       "userIcon": "github",
@@ -1727,6 +1809,7 @@
     "title": "キャリア25年目にしてTypeScript に出会うまで",
     "ogpTitle": "キャリア25年目にしてTypeScriptに出会うまで",
     "overview": "エンジニアとしてのキャリアをスタートしてから現在に至るまでの25年間、Java / Objective-C / Python / Swift などさまざまな言語でプログラミングしてきた私にとって、いま人気を集める TypeScript がどのように見えているかをお話しします。",
+    "slidesLink": "",
     "speaker": {
       "name": "かねうちてつや",
       "userIcon": "x",
@@ -1748,6 +1831,7 @@
     "title": "TypeScriptで実現する既存APIを活用したリモートMCPサーバー構築",
     "ogpTitle": "TypeScriptで実現する既存APIを活用した\nリモートMCPサーバー構築",
     "overview": "MCP（Model Context Protocol）とその周辺技術の発展に伴い、国内でもリモートMCPサーバーの活用事例が増えつつあります。一方で、構築に関する実践的な知見は、まだ十分に共有されているとは言えません。\r\n\r\n本セッションでは、TypeScriptを用いてリモートMCPサーバーをどのように迅速かつ実運用を前提とした形で構築したのかをご紹介します。新たにAPIを設計・実装するのではなく、既存のAPI資産を活用し、短期間で実用的な構成を実現しました。\r\n\r\nその過程で得られた知見を、アーキテクチャを中心に設計・実装・運用まで含めた全体像として整理し、実現方法にフォーカスしてお伝えします。また、モノレポやパッケージ管理による既存資産の再利用や、API仕様を起点とした構築など、TypeScriptの特性を活かした設計についても触れます。さらに、ユーザーにとって扱いやすい利用体験の設計についても取り上げます。\r\n\r\nMCPに関心のある方や、これからリモートMCPサーバーの構築を検討している方にとって、構築の一つのパターンとして参考にしつつ、リモートMCPサーバーの全体像を理解できるセッションを目指します。",
+    "slidesLink": "https://speakerdeck.com/soarteclab/tskaigi-2026",
     "speaker": {
       "name": "鈴木翔大",
       "userIcon": "x",
@@ -1769,6 +1853,7 @@
     "title": "10周年を迎えたZEN Study Webフロントエンドの次の10年へ向けた工夫",
     "ogpTitle": "10周年を迎えたZEN Study Webフロントエンドの\n次の10年へ向けた工夫",
     "overview": "ドワンゴ教育事業が提供する学習アプリ・ZEN Studyは、2026年4月にサービス開始から10周年を迎えました。10年間の積み重ねがあるコードをベースとして、今後10年間の新機能開発と保守を継続していくために組み入れている工夫を、TypeScriptの観点からお話しします。",
+    "slidesLink": "",
     "speaker": {
       "name": "小松 翔",
       "userIcon": "github",
@@ -1790,6 +1875,7 @@
     "title": "「バイトル」のTypeScriptリニューアル — 積み上がったレガシーとパフォーマンスに挑む現在地",
     "ogpTitle": "「バイトル」のTypeScriptリニューアル\n— 積み上がったレガシーと\nパフォーマンスに挑む現在地",
     "overview": "ディップ株式会社では、20年超の歴史を持つアルバイト求人サービス「バイトル」の大規模リニューアルの一環として、TypeScriptによる求職者向けサイトの刷新を進めています。\r\n\r\n求人メディアとしてのバイトルが抱える難しさと向き合いながら、パフォーマンス改善に取り組んでいる今と、これからの挑戦をお伝えします。",
+    "slidesLink": "",
     "speaker": {
       "name": "横山 隼",
       "userIcon": "github",
@@ -1811,6 +1897,7 @@
     "title": "OST (Open Space Technology)",
     "ogpTitle": "OST (Open Space Technology)",
     "overview": "OST（Open Space Technology）は、参加者全員が主役となり、自由にテーマを提案しながら議論を進める形式のイベントです。TypeScriptユーザー同士で自由に議論し、学び合える貴重な機会ですので、ぜひご参加ください。\r\n\r\n## 参加方法\r\n事前申し込みは不要です。当日、会場（RightTouchトラック）へお越しください。\r\n\r\n## テーマ募集\r\n会場に掲載しているGoogleフォームのQRコードにてOSTのテーマを募集します。TypeScriptについて「話したい」「聞きたい」テーマをぜひお寄せください。集まったテーマは運営チームが確認し、議題決定の参考にします。\r\n\r\n## 注意事項\r\n- 本企画は現地参加者のみを対象としています。\r\n- テーマの提案はどなたでも歓迎します。お気軽にご参加ください。",
+    "slidesLink": "",
     "speaker": {
       "name": "TSKaigi運営",
       "userIcon": "x",

--- a/src/constants/sessionMaster.ts
+++ b/src/constants/sessionMaster.ts
@@ -24,6 +24,7 @@ export type SessionMasterEntry = {
   speaker: SessionMasterSpeaker;
   id?: string;
   ogpTitle?: string;
+  slidesLink?: string;
 };
 
 const sessionMaster = sessionMasterData as Record<string, SessionMasterEntry>;

--- a/src/types/timetable-api.ts
+++ b/src/types/timetable-api.ts
@@ -14,6 +14,7 @@ export type SessionSummary = {
   id: string;
   title: string;
   overview?: string;
+  slidesLink?: string;
   speaker: {
     name: string;
     profileImageUrl?: string;

--- a/src/utils/getSession.ts
+++ b/src/utils/getSession.ts
@@ -19,9 +19,9 @@ export type SessionDetail = TimeSlot &
 function resolveSession(id: string): SessionSummary {
   const master = getSessionMasterBySessionId(id);
   if (master) {
-    const { title, overview, speaker } = master;
+    const { title, overview, slidesLink, speaker } = master;
     const { userIcon: _, ...rest } = speaker;
-    return { id, title, overview, speaker: rest };
+    return { id, title, overview, slidesLink, speaker: rest };
   }
   return { id, title: "", speaker: { name: "" } };
 }


### PR DESCRIPTION
- `speakers.json` の `slidesLink` をパイプライン (init-master / export-for-frontend) で素通しするよう修正
- `SessionMasterEntry` / `SessionSummary` に `slidesLink` を追加し、`getSession` で伝搬
- `TalkContent` に「登壇資料」セクションを追加（`slidesLink` がある場合のみ表示）
- 最新の `speakers.json` を反映、lacolaco さん分の URL も追加