### PR TITLE
feat: 登壇資料リンクをセッション開始時刻まで非公開にする

### DIFF
--- a/src/app/talks/[id]/SlidesSection.tsx
+++ b/src/app/talks/[id]/SlidesSection.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Link from "next/link";
+import { useSessionStarted } from "@/hooks/useSessionStarted";
+
+/**
+ * 登壇資料セクション。開始時刻前は公開予告メッセージ、開始後はリンクを表示する。
+ * 開始時刻のゲートはクライアント側で判定するため、このコンポーネント単位で
+ * "use client" を切ってある（親の TalkContent は server component のまま）。
+ */
+export function SlidesSection({
+  slidesLink,
+  startTime,
+}: {
+  slidesLink: string;
+  startTime: number;
+}) {
+  const isStarted = useSessionStarted(startTime);
+
+  return (
+    <div className="px-6 md:px-8 lg:px-10">
+      <h2 className="text-xl font-bold text-blue-light-500 border-b border-blue-light-500 pb-0.5 w-fit pr-2">
+        登壇資料
+      </h2>
+      {isStarted ? (
+        <Link
+          href={slidesLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-3 inline-flex items-center text-link-light hover:underline break-all"
+        >
+          {slidesLink}
+        </Link>
+      ) : (
+        <p className="mt-3 text-gray-700">
+          セッションの開始時間になりましたら公開いたします
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/talks/[id]/TalkContent.tsx
+++ b/src/app/talks/[id]/TalkContent.tsx
@@ -14,6 +14,7 @@ import { TrackHashtagActions } from "@/components/talks/TrackHashtagActions";
 import { TALK_TYPE } from "@/constants/timetable";
 import type { SessionDetail } from "@/utils/getSession";
 import { myTimetable } from "@/utils/myTimetable";
+import { SlidesSection } from "./SlidesSection";
 
 const components: ComponentProps<typeof Markdown>["components"] = {
   h1: ({ node, ...props }) => (
@@ -128,19 +129,7 @@ export function TalkContent({
         </div>
 
         {slidesLink && (
-          <div className="px-6 md:px-8 lg:px-10">
-            <h2 className="text-xl font-bold text-blue-light-500 border-b border-blue-light-500 pb-0.5 w-fit pr-2">
-              登壇資料
-            </h2>
-            <Link
-              href={slidesLink}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-3 inline-flex items-center text-link-light hover:underline break-all"
-            >
-              {slidesLink}
-            </Link>
-          </div>
+          <SlidesSection slidesLink={slidesLink} startTime={startTime} />
         )}
 
         <div className="mt-4 px-6 md:px-8 lg:px-10">

--- a/src/hooks/useSessionStarted.ts
+++ b/src/hooks/useSessionStarted.ts
@@ -1,0 +1,40 @@
+import { useSyncExternalStore } from "react";
+
+// useAskTheSpeakerActive と同じパターンで、購読者がいる間だけ 1 秒ティッカーを回し、
+// 各セッションの「開始時刻を過ぎたか」を共有 nowMs から判定する。
+// 値で比較されるため、開始時刻を跨いだ瞬間以外は再レンダリングされない。
+let nowMs = Date.now();
+const listeners = new Set<() => void>();
+let timer: ReturnType<typeof setInterval> | null = null;
+
+function subscribe(onStoreChange: () => void) {
+  listeners.add(onStoreChange);
+  if (timer === null) {
+    timer = setInterval(() => {
+      nowMs = Date.now();
+      for (const l of listeners) l();
+    }, 1000);
+  }
+  return () => {
+    listeners.delete(onStoreChange);
+    if (listeners.size === 0 && timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+}
+
+/**
+ * セッションの開始時刻を過ぎているかを返すフック。
+ * @param startTimeSec timetable のセル定義と同じく Unix 秒
+ *
+ * SSR 時はハイドレーション差分を避けるため常に false を返す
+ * （初回描画は「開始前」扱い、マウント後に現在時刻で更新）。
+ */
+export function useSessionStarted(startTimeSec: number): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    () => nowMs >= startTimeSec * 1000,
+    () => false,
+  );
+}


### PR DESCRIPTION
- `useSessionStarted` フックを追加。useAskTheSpeakerActive と同じ shared 1秒 ティッカー + useSyncExternalStore のパターンで、SSR スナップショットは false
- 登壇資料セクションを SlidesSection (client component) に分離
  - 開始時刻前: 「セッションの開始時間になりましたら公開いたします」
  - 開始時刻後: URL リンク
- 登壇者から「登壇が始まるまで公開したくない」要望への対応