### PR TITLE
fix: タイマーの自動ベルを強制終了到達時のみに変更

### DIFF
--- a/src/app/timekeep/page.tsx
+++ b/src/app/timekeep/page.tsx
@@ -57,19 +57,16 @@ export default function TimekeepPage() {
     unlock: unlockBell,
   } = useBell();
 
-  // 0秒到達でベルを鳴らす。セッション終了(→強制終了フェーズ)は1回、
-  // 強制終了は短く2回（チンチン）。
+  // 強制終了に到達したらベルを2回鳴らす（チンチン）。
   const prevPhaseRef = useRef(timer.phase);
   useEffect(() => {
     if (prevPhaseRef.current !== timer.phase) {
-      if (timer.phase === "forced") {
-        playBell();
-      } else if (timer.phase === "ended") {
+      if (timer.phase === "ended") {
         playBellDouble();
       }
       prevPhaseRef.current = timer.phase;
     }
-  }, [timer.phase, playBell, playBellDouble]);
+  }, [timer.phase, playBellDouble]);
 
   const fullscreenRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);


### PR DESCRIPTION
## Summary
- 持ち時間が0:00に到達した時の自動ベル（1回）を廃止しました。
- 自動で鳴るのは**強制終了（猶予2分）到達時の2回（チンチン）のみ**になります。
- 残り1分の予鈴は #410 で削除済み。手動の「ベルを鳴らす」ボタンは維持しています。

`src/app/timekeep/page.tsx` のフェーズ遷移ハンドラから `phase === "forced"` 時の `playBell()` を削除し、`phase === "ended"` 時の `playBellDouble()` のみ残しています。

## Test plan
- [ ] タイマー（セッション/カスタム）で持ち時間が0:00に到達してもベルが鳴らないこと
- [ ] 「強制終了まで」カウントが0:00に到達した時に2回鳴ること
- [ ] 「ベルを鳴らす」ボタンで手動再生できること
- [ ] 残り1分でオレンジの「まもなく終了」表示になる（ベルは鳴らない）こと

https://claude.ai/code/session_0184LPGNCT7iRQwtkZyYPzdX

---
_Generated by [Claude Code](https://claude.ai/code/session_0184LPGNCT7iRQwtkZyYPzdX)_