### PR TITLE
feat: X投稿ボタンを「URL+タグ」と「タグのみ」の2種類に分割

### DIFF
--- a/src/app/talks/[id]/OstContent.tsx
+++ b/src/app/talks/[id]/OstContent.tsx
@@ -57,6 +57,7 @@ export function OstContent({
                 hashtag: detail.hashtag,
               }}
               variant="compact"
+              talkUrl={`https://2026.tskaigi.org/talks/${session.id}`}
               className="mt-2"
             />
           </section>

--- a/src/app/talks/[id]/TalkContent.tsx
+++ b/src/app/talks/[id]/TalkContent.tsx
@@ -112,6 +112,7 @@ export function TalkContent({
               hashtag: detail.hashtag,
             }}
             variant="compact"
+            talkUrl={`https://2026.tskaigi.org/talks/${session.id}`}
             className="mt-2"
           />
         </div>

--- a/src/components/talks/TalkDetailDrawer/index.tsx
+++ b/src/components/talks/TalkDetailDrawer/index.tsx
@@ -238,6 +238,7 @@ function DrawerContent({ talk }: { talk: TalkWithMinutes }) {
         <TrackHashtagActions
           track={TRACK[talk.track]}
           variant="compact"
+          talkUrl={`https://2026.tskaigi.org/talks/${talk.id}`}
           className="mt-3"
         />
       </div>

--- a/src/components/talks/TrackHashtagActions/index.tsx
+++ b/src/components/talks/TrackHashtagActions/index.tsx
@@ -18,12 +18,15 @@ type Props = {
    * - "compact": トーク詳細用の小さめボタン（コピー＋X投稿）
    */
   variant?: "header" | "compact";
+  /** compact のみ: 「Xに投稿」ボタンで本文に含めるセッション詳細 URL */
+  talkUrl?: string;
   className?: string;
 };
 
 export function TrackHashtagActions({
   track,
   variant = "header",
+  talkUrl,
   className,
 }: Props) {
   const handleCopy = async () => {
@@ -35,10 +38,23 @@ export function TrackHashtagActions({
     }
   };
 
-  const handleOpenX = () => {
+  const handleOpenXWithUrl = () => {
     openXPostIntent({
-      deepLink: buildXTrackDeepLinkUrl(track.hashtag),
-      webFallback: buildXTrackIntentUrl(track.hashtag),
+      deepLink: buildXTrackDeepLinkUrl({
+        trackHashtag: track.hashtag,
+        url: talkUrl,
+      }),
+      webFallback: buildXTrackIntentUrl({
+        trackHashtag: track.hashtag,
+        url: talkUrl,
+      }),
+    });
+  };
+
+  const handleOpenXHashtagOnly = () => {
+    openXPostIntent({
+      deepLink: buildXTrackDeepLinkUrl({ trackHashtag: track.hashtag }),
+      webFallback: buildXTrackIntentUrl({ trackHashtag: track.hashtag }),
     });
   };
 
@@ -53,13 +69,23 @@ export function TrackHashtagActions({
           <span>{track.hashtag}</span>
           <Copy size={12} className="shrink-0 text-black-400" />
         </button>
+        {talkUrl && (
+          <button
+            type="button"
+            onClick={handleOpenXWithUrl}
+            className="inline-flex items-center gap-1.5 rounded-full bg-white border border-black-400 px-2.5 py-1 text-xs font-medium text-black-700 hover:bg-black-50 active:bg-black-100 cursor-pointer transition-colors"
+          >
+            <img src="/talks/sns/x-logo.png" alt="X" width={12} height={12} />
+            <span>に投稿</span>
+          </button>
+        )}
         <button
           type="button"
-          onClick={handleOpenX}
+          onClick={handleOpenXHashtagOnly}
           className="inline-flex items-center gap-1.5 rounded-full bg-white border border-black-400 px-2.5 py-1 text-xs font-medium text-black-700 hover:bg-black-50 active:bg-black-100 cursor-pointer transition-colors"
         >
           <img src="/talks/sns/x-logo.png" alt="X" width={12} height={12} />
-          <span>に投稿</span>
+          <span>タグのみ</span>
         </button>
       </div>
     );

--- a/src/utils/xIntent.ts
+++ b/src/utils/xIntent.ts
@@ -11,8 +11,8 @@ type PostMessageOptions = {
 function buildPostMessage({ trackHashtag, url }: PostMessageOptions): string {
   const trackTag = trackHashtag.replace(/^#/, "");
   const hashtags = ["#TSKaigi", "#TSKaigi2026", `#${trackTag}`].join(" ");
-  // "\n\n" で1行分の空行を作り、その下にハッシュタグ（と任意で URL）を並べる
-  const body = url ? `${hashtags}\n${url}` : hashtags;
+  // "\n\n" で1行分の空行を作り、その下に URL（任意）→ ハッシュタグの順で並べる
+  const body = url ? `${url}\n${hashtags}` : hashtags;
   return `\n\n${body}`;
 }
 

--- a/src/utils/xIntent.ts
+++ b/src/utils/xIntent.ts
@@ -1,17 +1,24 @@
+type PostMessageOptions = {
+  trackHashtag: string;
+  /** セッション詳細などへのリンク。指定するとハッシュタグの後ろに付与される。 */
+  url?: string;
+};
+
 /**
  * X 投稿画面の本文として埋め込むテキスト。
  * 先頭に空行を入れて、ハッシュタグの上にユーザーがコメントを書き足せる余白を作る。
  */
-function buildPostMessage(trackHashtag: string): string {
+function buildPostMessage({ trackHashtag, url }: PostMessageOptions): string {
   const trackTag = trackHashtag.replace(/^#/, "");
   const hashtags = ["#TSKaigi", "#TSKaigi2026", `#${trackTag}`].join(" ");
-  // "\n\n" で1行分の空行を作り、その下にハッシュタグを並べる
-  return `\n\n${hashtags}`;
+  // "\n\n" で1行分の空行を作り、その下にハッシュタグ（と任意で URL）を並べる
+  const body = url ? `${hashtags}\n${url}` : hashtags;
+  return `\n\n${body}`;
 }
 
 /** トラックのハッシュタグ入りで X 投稿画面を開く Web URL を生成する */
-export function buildXTrackIntentUrl(trackHashtag: string): string {
-  const text = buildPostMessage(trackHashtag);
+export function buildXTrackIntentUrl(options: PostMessageOptions): string {
+  const text = buildPostMessage(options);
   return `https://x.com/intent/post?text=${encodeURIComponent(text)}`;
 }
 
@@ -19,8 +26,8 @@ export function buildXTrackIntentUrl(trackHashtag: string): string {
  * X アプリ用の deep link を生成する。
  * `twitter://post?message=...` は iOS/Android の X アプリで投稿画面を開く。
  */
-export function buildXTrackDeepLinkUrl(trackHashtag: string): string {
-  const message = buildPostMessage(trackHashtag);
+export function buildXTrackDeepLinkUrl(options: PostMessageOptions): string {
+  const message = buildPostMessage(options);
   return `twitter://post?message=${encodeURIComponent(message)}`;
 }
 


### PR DESCRIPTION
実際の投稿パターンに合わせ、セッション詳細のURL付き投稿とタグのみ投稿を別ボタンに分けた。