### PR TITLE
feat: 当日案内の表示を下げ終了した旨の表記を追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import { JudgesSection } from "@/components/JudgesSection";
 import { KeynoteSection } from "@/components/KeynoteSection";
 import { MissionSection } from "@/components/MissionSection";
 import { NewsSection } from "@/components/NewsSection";
-import { OnTheDayLinksSection } from "@/components/OnTheDayLinkSection";
+// import { OnTheDayLinksSection } from "@/components/OnTheDayLinkSection";
 import PersonalSponsorsSection from "@/components/PersonalSponsorsSection";
 import { SponsorsBoardSection } from "@/components/SponsorsBoardSection";
 import { StaffSection } from "@/components/StaffSection";
@@ -18,7 +18,7 @@ export default async function Home() {
   return (
     <main className="w-full flex flex-col flex-1 items-center font-outfit pt-[60px] md:pt-[68px]">
       <HeroSection />
-      <OnTheDayLinksSection />
+      {/* <OnTheDayLinksSection /> */}
       <NewsSection />
       <MissionSection />
       <KeynoteSection />

--- a/src/components/MissionSection/index.tsx
+++ b/src/components/MissionSection/index.tsx
@@ -4,6 +4,11 @@ import { VenueInformation } from "../VenueInformation";
 function MissionSessionContent() {
   return (
     <div className="p-6 flex flex-col justify-center md:p-10 lg:max-w-[940px] lg:mx-auto lg:py-16">
+      <p className="text-xl md:text-4xl text-center font-bold my-8 md:mb-16">
+        TSKaigi 2026は終了しました。
+        <br />
+        ご参加いただきありがとうございました！
+      </p>
       <h2 className="text-sm text-center md:text-lg">MISSION</h2>
 
       <p className="text-blue-500 text-xl font-bold text-center mt-1 lg:mt-4 md:text-2xl lg:text-3xl">


### PR DESCRIPTION
<img width="1275" height="1153" alt="image" src="https://github.com/user-attachments/assets/fd5522d8-0e71-4884-9695-b6e83e30c107" />
