### PR TITLE
fix: サイドイベントのリンクから noreferrer を削除

### DIFF
--- a/src/app/side-events/_components/SideEventItem/index.tsx
+++ b/src/app/side-events/_components/SideEventItem/index.tsx
@@ -29,7 +29,6 @@ const SideEventItem = ({
           <a
             href={link}
             target="_blank"
-            rel="noreferrer"
             className="text-xl font-bold underline underline-offset-2 inline align-middle"
           >
             {name}
@@ -43,7 +42,7 @@ const SideEventItem = ({
         </h3>
         <div className="flex flex-col gap-5 lg:flex-row lg:gap-6">
           <div className="flex flex-col gap-5 shrink-0 lg:w-1/2">
-            <a href={link} target="_blank" rel="noreferrer">
+            <a href={link} target="_blank">
               <Image
                 src={thumbnail}
                 alt={name}

--- a/src/app/side-events/_components/SideEventItem/index.tsx
+++ b/src/app/side-events/_components/SideEventItem/index.tsx
@@ -29,6 +29,7 @@ const SideEventItem = ({
           <a
             href={link}
             target="_blank"
+            rel="noopener"
             className="text-xl font-bold underline underline-offset-2 inline align-middle"
           >
             {name}
@@ -42,7 +43,7 @@ const SideEventItem = ({
         </h3>
         <div className="flex flex-col gap-5 lg:flex-row lg:gap-6">
           <div className="flex flex-col gap-5 shrink-0 lg:w-1/2">
-            <a href={link} target="_blank">
+            <a href={link} target="_blank" rel="noopener">
               <Image
                 src={thumbnail}
                 alt={name}


### PR DESCRIPTION
サイドイベントページのイベントページへのリンクから rel="noreferrer" を
外し、リファラー（流入元）情報が送信されるようにする。

https://claude.ai/code/session_01DtHUgycnRCz6yYVmNJ7tNx